### PR TITLE
Add Known Issue for Missing VCRUNTIME140.dll and MSVCP140.dll in Windows 11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,9 +47,20 @@ Example:
 
 ## wperf-devgen.exe - Application Error
 
-If you see error:
+If you see below error when you try to run `wperf-devgen.exe`:
 
 > :warning: "The application was unable to start correctly (0xc000007b). Click OK to close this application."
 
-when you issue e.g. `wperf-devgen.exe` command please refer to [A Windows Error 0xC000007B](https://answers.microsoft.com/en-us/windows/forum/all/a-windows-error-0xc000007b/c25fbcb7-1162-487f-bd81-6d8314a52891) article.
+Please refer to [A Windows Error 0xC000007B](https://answers.microsoft.com/en-us/windows/forum/all/a-windows-error-0xc000007b/c25fbcb7-1162-487f-bd81-6d8314a52891) article.
+
 Usually errors like these are due to missing `vcredist` files. We suggest downloading the updated ones from Microsoft's page, for example [Latest Microsoft Visual C++ Redistributable Version](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).
+
+## wperf-devgen.exe - System Error
+
+If you see below error when you try to run `wperf-devgen.exe`:
+
+> :warning: "The code execution cannot proceed because MSVCP140.dll was not found. Reinstalling the program may fix this problem."
+
+Please refer to [VCRUNTIME140.dll and MSVCP140.dll missing in Windows 11](https://answers.microsoft.com/en-us/windows/forum/all/vcruntime140dll-and-msvcp140dll-missing-in-windows/caf454d1-49f4-4d2b-b74a-c83fb7c38625) article.
+
+Usually errors like these are due to missing `MSVCP140.dll` and `VCRUNTIME140.dll` files. We suggest downloading the updated ones from Microsoft's page, for example [Latest Microsoft Visual C++ Redistributable Version](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).

--- a/wperf-devgen/README.md
+++ b/wperf-devgen/README.md
@@ -7,6 +7,8 @@ The `wperf-devgen` project is a utility designed to facilitate the installation 
 Before running the executable make sure `wperf-driver.sys`, `wperf-driver.inf` and `wperf-driver.cat` are
 all at the same directory as the `wperf-devgen` executable. Make sure those file are properly signed by Linaro and Microsoft.
 
+> :warning: `wperf-devgen` requires latest Microsoft Visual C++ Redistributable version. If you encounter a `Runtime Error` (A Windows Error 0xC000007B) or a `System Error` (VCRUNTIME140.dll and MSVCP140.dll missing) during tool execution, please download and install the [latest Microsoft Visual C++ Redistributable Version](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).
+
 # Usage
 
 You can type `wperf-devgen install` to install the software device along with the driver. If some error occurs and


### PR DESCRIPTION
This pull request addresses two key updates:

- wperf-devgen: Added a note indicating that `wperf-devgen` requires the latest Microsoft Visual C++ Redistributable version.
- INSTALL Documentation Update: Added a known issue to the INSTALL guide regarding the missing `VCRUNTIME140.dll` and `MSVCP140.dll` in Windows 11.


These updates aim to improve user experience by providing necessary information on dependencies and known issues.