### PR TITLE
[wperf] Fix: The field samples_generated is always 0 (SPE)

### DIFF
--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -315,3 +315,21 @@ def test_cpython_bench_spe_consistency(request, tmp_path, EVENT,SPE_FILTERS,PYTH
             total_hits_pmu = events["counter_value"]
 
     assert total_hits == total_hits_pmu
+
+    #
+    # Check if `samples_generated` and `samples_dropped` match SPE PMU event values in counting
+    #
+    samples_generated = json_output["sampling"]["sampling"]["samples_generated"]
+    samples_dropped = json_output["sampling"]["sampling"]["samples_dropped"]
+
+    sample_pop = 0
+    sample_filtrate = 0
+
+    for events in json_output["counting"]["core"]["cores"][0]["Performance_counter"]:
+        if events["event_name"] == "sample_pop":
+            sample_pop = events["counter_value"]
+        if events["event_name"] == "sample_filtrate":
+            sample_filtrate = events["counter_value"]
+
+    assert samples_generated == sample_filtrate
+    assert samples_dropped == (sample_pop - sample_filtrate)

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -322,14 +322,12 @@ def test_cpython_bench_spe_consistency(request, tmp_path, EVENT,SPE_FILTERS,PYTH
     samples_generated = json_output["sampling"]["sampling"]["samples_generated"]
     samples_dropped = json_output["sampling"]["sampling"]["samples_dropped"]
 
-    sample_pop = 0
     sample_filtrate = 0
 
     for events in json_output["counting"]["core"]["cores"][0]["Performance_counter"]:
-        if events["event_name"] == "sample_pop":
-            sample_pop = events["counter_value"]
         if events["event_name"] == "sample_filtrate":
             sample_filtrate = events["counter_value"]
 
+    assert sample_filtrate >= 0
+    assert samples_dropped >= 0
     assert samples_generated == sample_filtrate
-    assert samples_dropped == (sample_pop - sample_filtrate)

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -792,14 +792,7 @@ wmain(
 
                     // Now we read just the core events and print the debugging information
                     pmu_device.core_events_read();
-                    pmu_device.print_core_stat(request.ioctl_events[EVT_CORE]);
-                    {
-                        // Add generated samples to SPE JSON sampling
-                        uint64_t samples_generated = pmu_device.get_core_stat_by_name(L"sample_filtrate", request.ioctl_events[EVT_CORE]);
-                        uint64_t samples_pop = pmu_device.get_core_stat_by_name(L"sample_pop", request.ioctl_events[EVT_CORE]);
-                        m_globalSamplingJSON.m_samples_generated = samples_generated;
-                        m_globalSamplingJSON.m_samples_dropped = samples_pop - samples_generated;
-                    }
+                    pmu_device.spe_print_core_stats(request.ioctl_events[EVT_CORE]);
                 } else {
                     pmu_device.stop_sample();
                 }

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -783,7 +783,7 @@ wmain(
 
                 m_out.GetOutputStream() << " done!" << std::endl;
 
-                if(request.m_sampling_with_spe)
+                if (request.m_sampling_with_spe)
                 {
                     // We stop the SPE first so we don't miss any PMU events
                     pmu_device.spe_stop();
@@ -794,8 +794,13 @@ wmain(
                     pmu_device.core_events_read();
                     pmu_device.print_core_stat(request.ioctl_events[EVT_CORE]);
                     pmu_device.print_core_metrics(request.ioctl_events[EVT_CORE]);
-                    // Add generated samples to SPE JSON sampling
-                    m_globalSamplingJSON.m_samples_generated = pmu_device.get_core_stat_by_name(L"sample_filtrate", request.ioctl_events[EVT_CORE]);
+                    {
+                        // Add generated samples to SPE JSON sampling
+                        uint64_t samples_generated = pmu_device.get_core_stat_by_name(L"sample_filtrate", request.ioctl_events[EVT_CORE]);
+                        uint64_t samples_pop = pmu_device.get_core_stat_by_name(L"sample_pop", request.ioctl_events[EVT_CORE]);
+                        m_globalSamplingJSON.m_samples_generated = samples_generated;
+                        m_globalSamplingJSON.m_samples_dropped = samples_pop - samples_generated;
+                    }
                 } else {
                     pmu_device.stop_sample();
                 }

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -793,7 +793,6 @@ wmain(
                     // Now we read just the core events and print the debugging information
                     pmu_device.core_events_read();
                     pmu_device.print_core_stat(request.ioctl_events[EVT_CORE]);
-                    pmu_device.print_core_metrics(request.ioctl_events[EVT_CORE]);
                     {
                         // Add generated samples to SPE JSON sampling
                         uint64_t samples_generated = pmu_device.get_core_stat_by_name(L"sample_filtrate", request.ioctl_events[EVT_CORE]);

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -744,10 +744,11 @@ wmain(
                     pmu_device.start(enable_bits);
                     pmu_device.spe_start(request.m_sampling_flags);
                 }
-                else pmu_device.start_sample();
+                else {
+                    pmu_device.start_sample();
+                }
 
                 m_out.GetOutputStream() << L"sampling ...";
-
                 
                 GetSystemTime(&timestamp_a);
 
@@ -789,7 +790,7 @@ wmain(
                     pmu_device.spe_get();
                     pmu_device.stop(enable_bits);
 
-                    // Now we read jus the core events and print the debugging information
+                    // Now we read just the core events and print the debugging information
                     pmu_device.core_events_read();
                     pmu_device.print_core_stat(request.ioctl_events[EVT_CORE]);
                     pmu_device.print_core_metrics(request.ioctl_events[EVT_CORE]);

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -794,6 +794,8 @@ wmain(
                     pmu_device.core_events_read();
                     pmu_device.print_core_stat(request.ioctl_events[EVT_CORE]);
                     pmu_device.print_core_metrics(request.ioctl_events[EVT_CORE]);
+                    // Add generated samples to SPE JSON sampling
+                    m_globalSamplingJSON.m_samples_generated = pmu_device.get_core_stat_by_name(L"sample_filtrate", request.ioctl_events[EVT_CORE]);
                 } else {
                     pmu_device.stop_sample();
                 }

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -3131,6 +3131,17 @@ const wchar_t* pmu_device::pmu_events_get_event_name(uint16_t index, enum evt_cl
     return pmu_events::get_event_name(index, e_class);
 }
 
+uint16_t pmu_device::pmu_events_get_event_index(std::wstring ename, enum evt_class e_class)
+{
+    if (e_class == EVT_CORE && m_product_events.count(m_product_name))
+        for (const auto& [key, value] : m_product_events[m_product_name])
+            if (value.name == std::wstring(ename))
+                return value.index;
+
+    return pmu_events::get_event_index(ename, e_class);
+}
+
+
 const wchar_t* pmu_device::pmu_events_get_evt_name_prefix(enum evt_class e_class)
 {
     return pmu_events::get_evt_name_prefix(e_class);

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -387,9 +387,7 @@ void pmu_device::spe_print_core_stats(std::vector<struct evt_noted>& events)
 
     // Add generated samples to SPE JSON sampling
     uint64_t samples_generated = get_core_stat_by_name(L"sample_filtrate", events);
-    uint64_t samples_pop = get_core_stat_by_name(L"sample_pop", events);
     m_globalSamplingJSON.m_samples_generated = samples_generated;
-    m_globalSamplingJSON.m_samples_dropped = samples_pop - samples_generated;
 }
 
 void pmu_device::core_init()

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -380,6 +380,18 @@ void pmu_device::spe_stop()
         throw fatal_exception("PMU_CTL_SPE_STOP failed");
 }
 
+// Print PMU core stats related to SPE and update some JSON global data for printing
+void pmu_device::spe_print_core_stats(std::vector<struct evt_noted>& events)
+{
+    print_core_stat(events);
+
+    // Add generated samples to SPE JSON sampling
+    uint64_t samples_generated = get_core_stat_by_name(L"sample_filtrate", events);
+    uint64_t samples_pop = get_core_stat_by_name(L"sample_pop", events);
+    m_globalSamplingJSON.m_samples_generated = samples_generated;
+    m_globalSamplingJSON.m_samples_dropped = samples_pop - samples_generated;
+}
+
 void pmu_device::core_init()
 {
     query_hw_cfg(m_hw_cfg);

--- a/wperf/pmu_device.h
+++ b/wperf/pmu_device.h
@@ -179,6 +179,7 @@ public:
     // Events
     const wchar_t* pmu_events_get_evt_class_name(enum evt_class e_class);
     const wchar_t* pmu_events_get_event_name(uint16_t index, enum evt_class e_class = EVT_CORE);
+    uint16_t pmu_events_get_event_index(std::wstring ename, enum evt_class e_class = EVT_CORE);
     const wchar_t* pmu_events_get_evt_name_prefix(enum evt_class e_class);
     const wchar_t* pmu_events_get_evt_desc(uint16_t index, enum evt_class e_class = EVT_CORE);
 

--- a/wperf/pmu_device.h
+++ b/wperf/pmu_device.h
@@ -179,7 +179,7 @@ public:
     // Events
     const wchar_t* pmu_events_get_evt_class_name(enum evt_class e_class);
     const wchar_t* pmu_events_get_event_name(uint16_t index, enum evt_class e_class = EVT_CORE);
-    uint16_t pmu_events_get_event_index(std::wstring ename, enum evt_class e_class = EVT_CORE);
+    int pmu_events_get_event_index(std::wstring ename, enum evt_class e_class = EVT_CORE);
     const wchar_t* pmu_events_get_evt_name_prefix(enum evt_class e_class);
     const wchar_t* pmu_events_get_evt_desc(uint16_t index, enum evt_class e_class = EVT_CORE);
 
@@ -195,6 +195,8 @@ public:
     void dmc_events_read(void);
     void events_query(std::map<enum evt_class, std::vector<uint16_t>>& events_out);         // Query for events available to the user
     void events_query_driver(std::map<enum evt_class, std::vector<uint16_t>>& events_out);  // Query driver for known events
+
+    uint64_t get_core_stat_by_name(std::wstring ename, std::vector<struct evt_noted>& events);
 
     void print_core_stat(std::vector<struct evt_noted>& events); 
     void print_dsu_stat(std::vector<struct evt_noted>& events, bool report_l3_metric);

--- a/wperf/pmu_device.h
+++ b/wperf/pmu_device.h
@@ -128,6 +128,7 @@ public:
     void spe_start(const std::map<std::wstring, bool>& flags);
     void spe_stop();
     bool spe_get();
+    void pmu_device::spe_print_core_stats(std::vector<struct evt_noted>& events);
 
     size_t m_spe_size_to_copy;
     std::vector<UINT8> m_spe_buffer;


### PR DESCRIPTION
## Description

This PR enhances the wperf tool with several updates:

- Update `test_cpython_bench_spe_consistency` to include 'samples_generated'.
- Add `spe_print_core_stats()` function.
- Remove TS metrics printout.
- Populate 'samples_generated'.
- Add missing 'samples_generated' in JSON output.
- Update `pmu_events_get_event_index()` function.
- Minor code style and typo fixes.

## Related Issue

Closes #12 

## Commits

## How Has This Been Tested?

```
>pytest -v wperf_cli_cpython_dep_record_spe_test.py
=============================================================================================================== test session starts ===============================================================================================================
cachedir: .pytest_cache
configfile: pytest.ini
collected 49 items

wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[x] PASSED                                                                                                                                              [  2%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[_] PASSED                                                                                                                                              [  4%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[asdasd] PASSED                                                                                                                                         [  6%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[b] PASSED                                                                                                                                              [  8%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[ld] PASSED                                                                                                                                             [ 10%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[st] PASSED                                                                                                                                             [ 12%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter] PASSED                                                                                                                                    [ 14%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[store_filter] PASSED                                                                                                                                   [ 16%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[branch_filter] PASSED                                                                                                                                  [ 18%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,x] PASSED                                                                                                                                [ 20%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,_] PASSED                                                                                                                                [ 22%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,asdasd] PASSED                                                                                                                           [ 24%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,b] PASSED                                                                                                                                [ 26%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,ld] PASSED                                                                                                                               [ 28%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,st] PASSED                                                                                                                               [ 30%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,load_filter] PASSED                                                                                                                      [ 32%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,store_filter] PASSED                                                                                                                     [ 34%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter[load_filter=0,branch_filter] PASSED                                                                                                                    [ 36%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_name[=0] PASSED                                                                                                                                        [ 38%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_name[=1] PASSED                                                                                                                                        [ 40%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_name[load_filter=0,=0] PASSED                                                                                                                          [ 42%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_name[load_filter=0,=1] PASSED                                                                                                                          [ 44%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=] PASSED                                                                                                                             [ 46%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[store_filter=] PASSED                                                                                                                            [ 48%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[branch_filter=] PASSED                                                                                                                           [ 51%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[ld=] PASSED                                                                                                                                      [ 53%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[st=] PASSED                                                                                                                                      [ 55%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[b=] PASSED                                                                                                                                       [ 57%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=3] PASSED                                                                                                                            [ 59%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=a] PASSED                                                                                                                            [ 61%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=one] PASSED                                                                                                                          [ 63%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,load_filter=] PASSED                                                                                                               [ 65%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,store_filter=] PASSED                                                                                                              [ 67%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,branch_filter=] PASSED                                                                                                             [ 69%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,ld=] PASSED                                                                                                                        [ 71%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,st=] PASSED                                                                                                                        [ 73%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,b=] PASSED                                                                                                                         [ 75%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,load_filter=3] PASSED                                                                                                              [ 77%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,load_filter=a] PASSED                                                                                                              [ 79%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_cli_incorrect_filter_value[load_filter=0,load_filter=one] PASSED                                                                                                            [ 81%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_hotspot[arm_spe_0--x_mul:python312_d.dll-65-10**10**100] PASSED                                                                                                             [ 83%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_hotspot[arm_spe_0-load_filter=1-x_mul:python312_d.dll-65-10**10**100] PASSED                                                                                                [ 85%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_schema[arm_spe_0--10**10**100] PASSED                                                                                                                                  [ 87%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_schema[arm_spe_0-load_filter=1-10**10**100] PASSED                                                                                                                     [ 89%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_stdout_schema[arm_spe_0--10**10**100] PASSED                                                                                                                           [ 91%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_stdout_schema[arm_spe_0-load_filter=1-10**10**100] PASSED                                                                                                              [ 93%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_consistency[arm_spe_0--10**10**100] PASSED                                                                                                                                  [ 95%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_consistency[arm_spe_0-load_filter=1-10**10**100] PASSED                                                                                                                     [ 97%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_consistency[arm_spe_0-load_filter=1,st=1-10**10**100] PASSED                                                                                                                [100%]
========================================================================================================= WindowsPerf Test Configuration ==========================================================================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 22/10/2024, 05:45:39
wperf: 3.8.0.ae2bc935-dirty+etw-app+spe
wperf-driver: 3.8.0.5805a5e6-dirty+trace+spe

========================================================================================================= 49 passed in 138.56s (0:02:18) ==========================================================================================================
```
