### PR TITLE
Fix issue with how we index maps in manual

### DIFF
--- a/wperf-scripts/tests/wperf_cli_man_test.py
+++ b/wperf-scripts/tests/wperf_cli_man_test.py
@@ -61,7 +61,7 @@ def test_wperf_man_not_compatible_cpu_throws(cpu, argument):
     expected_error = f"warning: \"{argument}\" not found! Ensure it is compatible with the specified CPU".encode()
     assert expected_error in stderr
 
-# Note - stacked parametrizations creates permutations
+# Note - stacked parameterizations creates permutations
 @pytest.mark.parametrize("cpu",
 [
     (""),

--- a/wperf-scripts/tests/wperf_cli_man_test.py
+++ b/wperf-scripts/tests/wperf_cli_man_test.py
@@ -38,7 +38,7 @@ from common import run_command
 ### Test cases
 
 def test_wperf_man_help():
-    """ Test `wperf man` with no arg"""
+    """ Test `wperf man` with no args"""
     cmd = 'wperf man'
     _, stderr = run_command(cmd.split())
 
@@ -55,7 +55,7 @@ def test_wperf_man_help():
 def test_wperf_man_not_compatible_cpu_throws(cpu, argument):
     """Test `wperf man` when prompted with invalid CPUs throws the necessary error"""
     cmd = f'wperf man {cpu}/{argument}'
-    _,stderr = run_command(cmd.split())
+    _, stderr = run_command(cmd.split())
 
     assert b"unexpected arg" not in stderr
     expected_error = f"warning: \"{argument}\" not found! Ensure it is compatible with the specified CPU".encode()
@@ -82,10 +82,92 @@ def test_wperf_man_not_compatible_cpu_throws(cpu, argument):
 ]
 )
 def test_wperf_man_invalid_cpu_throws(cpu, argument):
-    """Test `wperf man` when prompted with invlaid CPUs throws the necessary error"""
+    """Test `wperf man` when prompted with invalid CPUs throws the necessary error"""
     cmd = f'wperf man {cpu}/{argument}'
-    _,stderr = run_command(cmd.split())
+    _, stderr = run_command(cmd.split())
 
     assert b"unexpected arg" not in stderr
     expected_error = f"warning: CPU name: \"{cpu}\" not found, use".encode()
     assert expected_error in stderr
+
+#
+# NOK cases for armv8-a / armv9-a
+#
+
+@pytest.mark.parametrize("cpu, argument",
+[
+    # This events are not present in given CPU
+    ("armv8-a", "trcextout0"),
+    ("armv8-a", "trcextout1"),
+    ("armv8-a", "trcextout2"),
+    ("armv8-a", "trcextout3"),
+]
+)
+def test_wperf_man_not_compatible_cpu_event_err(cpu, argument):
+    """Test `wperf man` when prompted with invalid CPUs throws the necessary error"""
+    cmd = f'wperf man {cpu}/{argument}'
+    _, stderr = run_command(cmd.split())
+
+    assert b"unexpected arg" not in stderr
+    expected_error = f"warning: \"{argument}\" not found! Ensure it is compatible with the specified CPU".encode()
+    assert expected_error in stderr
+
+#
+# OK cases for armv8-a / armv9-a
+#
+
+# Note - stacked parameterizations creates permutations
+@pytest.mark.parametrize("cpu",
+[
+    ("armv8-a"),
+    ("armv9-a"),
+]
+)
+@pytest.mark.parametrize("argument",
+[
+    ("ld_spec"),
+    ("remote_access_rd"),
+    ("l3d_cache_lmiss_rd"),
+    ("stall_frontend_membound"),
+    ("br_immed_mis_pred_retired"),
+]
+)
+def test_wperf_man_armv89_common_events(cpu, argument):
+    """Test `wperf man` when prompted with invalid CPUs throws the necessary error"""
+    cmd = f'wperf man {cpu}/{argument}'
+    stdout, stderr = run_command(cmd.split())
+
+    assert b"unexpected arg" not in stderr
+    assert b"warning:" not in stderr
+    assert b"CPU" in stdout
+    assert b"NAME" in stdout
+    assert b"DESCRIPTION" in stdout
+
+# Note - stacked parameterizations creates permutations
+@pytest.mark.parametrize("cpu",
+[
+    ("armv9-a"),
+    ("neoverse-n2"),
+    ("neoverse-v2"),
+    ("neoverse-n3"),
+]
+)
+@pytest.mark.parametrize("argument",
+[
+    ("trb_wrap"),
+    ("trcextout0"),
+    ("trcextout1"),
+    ("trcextout2"),
+    ("trcextout3"),
+]
+)
+def test_wperf_man_armv9_n23_v2_common_events(cpu, argument):
+    """Test `wperf man` when prompted with invalid CPUs throws the necessary error"""
+    cmd = f'wperf man {cpu}/{argument}'
+    stdout, stderr = run_command(cmd.split())
+
+    assert b"unexpected arg" not in stderr
+    assert b"warning:" not in stderr
+    assert b"CPU" in stdout
+    assert b"NAME" in stdout
+    assert b"DESCRIPTION" in stdout

--- a/wperf/man.cpp
+++ b/wperf/man.cpp
@@ -112,29 +112,28 @@ bool static man_find_in_product_data(const pmu_device& pdev, std::wstring produc
 			product_name = pdev.get_product_name(product_name);
 		}
 
-		const auto& metrics_map = pdev.m_product_metrics.at(product_name);
-		const auto& events_map = pdev.m_product_events.at(product_name);
-		const auto& group_metrics_map = pdev.m_product_groups_metrics.at(product_name);
-
-		if (metrics_map.find(requested_arg) != metrics_map.end()) 
+		if (pdev.m_product_metrics.count(product_name) &&
+			pdev.m_product_metrics.at(product_name).count(requested_arg))
 		{
 			requested_items.push_back({ man_Item::Metric, product_name, requested_arg });
 			return true;
 		}
-		else if (events_map.find(requested_arg) != events_map.end()) 
+
+		if (pdev.m_product_events.count(product_name) &&
+			pdev.m_product_events.at(product_name).count(requested_arg))
 		{
 			requested_items.push_back({ man_Item::Event, product_name, requested_arg });
 			return true;
 		}
-		else if (group_metrics_map.find(requested_arg) != group_metrics_map.end()) 
+
+		if (pdev.m_product_groups_metrics.count(product_name) &&
+			pdev.m_product_groups_metrics.at(product_name).count(requested_arg))
 		{
 			requested_items.push_back({ man_Item::Group_Metric, product_name, requested_arg });
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 	catch (const std::out_of_range&) {
 		return false;


### PR DESCRIPTION
## Description

On `armv8-a` machine we can see simple `wperf man ld_spec` is not working well.

We can see:

```command
wperf man ld_spec
wperf man armv8-a/ld_spec
```
Cause:
```output
warning: "ld_spec" not found! Ensure it is compatible with the specified CPU
```

## Commits

## How Has This Been Tested?

```
>pytest -v wperf_cli_man_test.py
========================================================== test session starts ===========================================================
configfile: pytest.ini
collected 65 items

wperf_cli_man_test.py::test_wperf_man_help PASSED                                                                                   [  1%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_throws[armv8-a-Operation_Mix] PASSED                                       [  3%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_throws[armv9-a-Operation_Mix] PASSED                                       [  4%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ld_spec-] PASSED                                                           [  6%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ld_spec-.!!33] PASSED                                                      [  7%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ld_spec-never-verse-n1] PASSED                                             [  9%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ld_spec-new_arm_cpu] PASSED                                                [ 10%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ipc-] PASSED                                                               [ 12%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ipc-.!!33] PASSED                                                          [ 13%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ipc-never-verse-n1] PASSED                                                 [ 15%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[ipc-new_arm_cpu] PASSED                                                    [ 16%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[sw_incr-] PASSED                                                           [ 18%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[sw_incr-.!!33] PASSED                                                      [ 20%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[sw_incr-never-verse-n1] PASSED                                             [ 21%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[sw_incr-new_arm_cpu] PASSED                                                [ 23%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SAMPLE_COLLISION-] PASSED                                                  [ 24%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SAMPLE_COLLISION-.!!33] PASSED                                             [ 26%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SAMPLE_COLLISION-never-verse-n1] PASSED                                    [ 27%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SAMPLE_COLLISION-new_arm_cpu] PASSED                                       [ 29%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[Miss_Ratio-] PASSED                                                        [ 30%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[Miss_Ratio-.!!33] PASSED                                                   [ 32%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[Miss_Ratio-never-verse-n1] PASSED                                          [ 33%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[Miss_Ratio-new_arm_cpu] PASSED                                             [ 35%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[MEMORY_ERROR-] PASSED                                                      [ 36%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[MEMORY_ERROR-.!!33] PASSED                                                 [ 38%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[MEMORY_ERROR-never-verse-n1] PASSED                                        [ 40%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[MEMORY_ERROR-new_arm_cpu] PASSED                                           [ 41%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SVE_INST_SPEC-] PASSED                                                     [ 43%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SVE_INST_SPEC-.!!33] PASSED                                                [ 44%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SVE_INST_SPEC-never-verse-n1] PASSED                                       [ 46%]
wperf_cli_man_test.py::test_wperf_man_invalid_cpu_throws[SVE_INST_SPEC-new_arm_cpu] PASSED                                          [ 47%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_event_err[armv8-a-trcextout0] PASSED                                       [ 49%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_event_err[armv8-a-trcextout1] PASSED                                       [ 50%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_event_err[armv8-a-trcextout2] PASSED                                       [ 52%]
wperf_cli_man_test.py::test_wperf_man_not_compatible_cpu_event_err[armv8-a-trcextout3] PASSED                                       [ 53%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[ld_spec-armv8-a] PASSED                                                  [ 55%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[ld_spec-armv9-a] PASSED                                                  [ 56%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[remote_access_rd-armv8-a] PASSED                                         [ 58%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[remote_access_rd-armv9-a] PASSED                                         [ 60%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[l3d_cache_lmiss_rd-armv8-a] PASSED                                       [ 61%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[l3d_cache_lmiss_rd-armv9-a] PASSED                                       [ 63%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[stall_frontend_membound-armv8-a] PASSED                                  [ 64%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[stall_frontend_membound-armv9-a] PASSED                                  [ 66%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[br_immed_mis_pred_retired-armv8-a] PASSED                                [ 67%]
wperf_cli_man_test.py::test_wperf_man_armv89_common_events[br_immed_mis_pred_retired-armv9-a] PASSED                                [ 69%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trb_wrap-armv9-a] PASSED                                           [ 70%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trb_wrap-neoverse-n2] PASSED                                       [ 72%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trb_wrap-neoverse-v2] PASSED                                       [ 73%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trb_wrap-neoverse-n3] PASSED                                       [ 75%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout0-armv9-a] PASSED                                         [ 76%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout0-neoverse-n2] PASSED                                     [ 78%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout0-neoverse-v2] PASSED                                     [ 80%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout0-neoverse-n3] PASSED                                     [ 81%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout1-armv9-a] PASSED                                         [ 83%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout1-neoverse-n2] PASSED                                     [ 84%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout1-neoverse-v2] PASSED                                     [ 86%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout1-neoverse-n3] PASSED                                     [ 87%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout2-armv9-a] PASSED                                         [ 89%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout2-neoverse-n2] PASSED                                     [ 90%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout2-neoverse-v2] PASSED                                     [ 92%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout2-neoverse-n3] PASSED                                     [ 93%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout3-armv9-a] PASSED                                         [ 95%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout3-neoverse-n2] PASSED                                     [ 96%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout3-neoverse-v2] PASSED                                     [ 98%]
wperf_cli_man_test.py::test_wperf_man_armv9_n23_v2_common_events[trcextout3-neoverse-n3] PASSED                                     [100%]
===================================================== WindowsPerf Test Configuration =====================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 24/10/2024, 03:47:51
wperf: 3.8.0.0e36b4ca+etw-app
wperf-driver: 3.8.0.5805a5e6-dirty+trace+spe

=========================================================== 65 passed in 4.66s ===========================================================
```
