### PR TITLE
[wperf] Fix warning C6001: Using uninitialized memory 'fName'

### DIFF
--- a/wperf/pe_file.cpp
+++ b/wperf/pe_file.cpp
@@ -338,7 +338,7 @@ void read_function_lines(FuncSymDesc& funcSymDesc, IDiaSymbol* pSymbol, IDiaSess
                         }
 
                         funcSymDesc.lines.push_back(LineNumberDesc{
-                            std::wstring(fName),
+                            std::wstring(file_name_wstr),
                             linenum,
                             colnum,
                             isStatement,


### PR DESCRIPTION
## Description

With new SDK, WDK I've found this small issue with a warning:
```
.\windowsperf\wperf\pe_file.cpp(341): warning C6001: Using uninitialized memory 'fName'.
.\windowsperf\wperf\pe_file.cpp(341): warning C6001: Using uninitialized memory '*fName'.
```

## How Has This Been Tested?

```

```
