### PR TITLE
[wperf] "A sub-expression may overflow before being assigned to a wider type" warning

### DIFF
--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -143,7 +143,7 @@ namespace SPEParser
                     m_type = type;
                     m_header0 = byte;
                     m_state = ParsingState::READING_DATA;
-                    m_bytes_to_read = ((m_header0 & (~MASK_MIDDLE)) >> 4) + 1;
+                    m_bytes_to_read = (static_cast<size_t>((m_header0 & (~MASK_MIDDLE)) >> 4)) + 1;
                     break;
                 }
                 case PacketType::OPERATION_TYPE:


### PR DESCRIPTION
## Description

A small warning nit related to how we add `1` to uint8 before assigning to `size_t`.

## How Has This Been Tested?

```
>pytest wperf_cli_cpython_dep_record_spe_test.py
========================================================== test session starts ===========================================================
platform win32 -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
configfile: pytest.ini
collected 49 items

wperf_cli_cpython_dep_record_spe_test.py .................................................                                          [100%]
===================================================== WindowsPerf Test Configuration =====================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 30/10/2024, 04:03:06
wperf: 3.8.0.fb928fde+etw-app+spe
wperf-driver: 3.8.0.0d3eba3d-dirty+trace+spe

===================================================== 49 passed in 139.04s (0:02:19) =====================================================
```
