### PR TITLE
[wperf] fix: use corrent data structure size

### DIFF
--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -357,7 +357,7 @@ void pmu_device::spe_start(const std::map<std::wstring, bool>& flags)
     ctl.interval = 1024;
     ctl.config_flags = 0;
 
-    BOOL status = DeviceAsyncIoControl(m_device_handle, PMU_CTL_SPE_START, &ctl, sizeof(struct pmu_ctl_hdr), NULL, 0, &res_len);
+    BOOL status = DeviceAsyncIoControl(m_device_handle, PMU_CTL_SPE_START, &ctl, sizeof(struct spe_ctl_hdr), NULL, 0, &res_len);
     if (!status)
         throw fatal_exception("PMU_CTL_SPE_START failed");
         


### PR DESCRIPTION
## Description

There's a wrong data structure size used for call in `pmu_device::spe_start()`.

We want to use `struct spe_ctl_hdr` size, not `struct pmu_ctl_hdr` which is ~20B smaller 🫨 

## How Has This Been Tested?

```
TODO
```
