### PR TITLE
[wperf,wperf-driver] [SPE] Add new ts_enable filter to arm_spe_0//

### DIFF
--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -259,11 +259,11 @@ struct spe_ctl_hdr
 #define SPE_OPERATON_FILTER_B  0b001
 #define SPE_OPERATON_FILTER_LD 0b010
 #define SPE_OPERATON_FILTER_ST 0b100
-#define SPE_OPERATON_FILTER_TS 0b1000
     UINT64 event_filter;
     UINT64 config_flags;
     UINT32 interval;
 #define SPE_CTL_FLAG_RND (0x1 << 0)
+#define SPE_CTL_FLAG_TS  (0x1 << 1)
 };
 
 //

--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -262,8 +262,8 @@ struct spe_ctl_hdr
     UINT64 event_filter;
     UINT64 config_flags;
     UINT32 interval;
-#define SPE_CTL_FLAG_RND (0x1 << 0)
-#define SPE_CTL_FLAG_TS  (0x1 << 1)
+#define SPE_CTL_FLAG_RND (0x1 << 0)     // config_flags: jitter filter flag
+#define SPE_CTL_FLAG_TS  (0x1 << 1)     // config_flags: ts_enable filter flag
 };
 
 //

--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -259,6 +259,7 @@ struct spe_ctl_hdr
 #define SPE_OPERATON_FILTER_B  0b001
 #define SPE_OPERATON_FILTER_LD 0b010
 #define SPE_OPERATON_FILTER_ST 0b100
+#define SPE_OPERATON_FILTER_TS 0b1000
     UINT64 event_filter;
     UINT64 config_flags;
     UINT32 interval;

--- a/wperf-driver/spe.c
+++ b/wperf-driver/spe.c
@@ -99,6 +99,13 @@ VOID SPEWorkItemFunc(WDFWORKITEM WorkItem)
             }
             */
 
+            if (context->config_flags & SPE_CTL_FLAG_TS)
+            {
+                // Enable timestamps with ts_enable filter:
+                _WriteStatusReg(PMSICR_EL1, _ReadStatusReg(PMSICR_EL1) | BIT(5));   // TS, bit [5]
+                KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "SPE: ts_enable=1 PMSICR_EL1=0x%llX\n", _ReadStatusReg(PMSICR_EL1)));
+            }
+
             _WriteStatusReg(PMBSR_EL1, _ReadStatusReg(PMBSR_EL1) & (~PMBSR_EL1_S)); // Clear PMBSR_EL1.S
             //PMBPTR_EL1[63:56] must equal PMBLIMITR_EL1.LIMIT[63:56]
             _WriteStatusReg(PMBLIMITR_EL1, (UINT64)SpeMemoryBufferLimit | PMBLIMITR_EL1_E); // Enable PMBLIMITR_ELI1.E

--- a/wperf-driver/spe.c
+++ b/wperf-driver/spe.c
@@ -99,6 +99,11 @@ VOID SPEWorkItemFunc(WDFWORKITEM WorkItem)
             }
             */
 
+            /*
+            * Configure PMSCR_EL1 settings based on user-space flags. By default all settings are disabled
+            * (we zero the register). When user selects flag, e.g. /ts_enable=1/ we enable given setting
+            * (e.g. TS bit) to "ON" in this register.
+            */
             _WriteStatusReg(PMSCR_EL1, 0x00);
             if (context->config_flags & SPE_CTL_FLAG_TS)
             {

--- a/wperf-driver/spe.c
+++ b/wperf-driver/spe.c
@@ -99,11 +99,13 @@ VOID SPEWorkItemFunc(WDFWORKITEM WorkItem)
             }
             */
 
+            _WriteStatusReg(PMSCR_EL1, 0x00);
             if (context->config_flags & SPE_CTL_FLAG_TS)
             {
                 // Enable timestamps with ts_enable filter:
-                _WriteStatusReg(PMSICR_EL1, _ReadStatusReg(PMSICR_EL1) | BIT(5));   // TS, bit [5]
-                KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "SPE: ts_enable=1 PMSICR_EL1=0x%llX\n", _ReadStatusReg(PMSICR_EL1)));
+                UINT64 pmscr_el1_val = 0x00 | BIT(5);   // PMSCR_EL1.TS
+                _WriteStatusReg(PMSCR_EL1, pmscr_el1_val);
+                KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "SPE: ts_enable=1 PMSICR_EL1=0x%llX\n", _ReadStatusReg(PMSCR_EL1) & 0b11111011));
             }
 
             _WriteStatusReg(PMBSR_EL1, _ReadStatusReg(PMBSR_EL1) & (~PMBSR_EL1_S)); // Clear PMBSR_EL1.S

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -127,12 +127,15 @@ def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
     ("load_filter="),
     ("store_filter="),
     ("branch_filter="),
+    ("ts_enable="),
     ("ld="),
     ("st="),
     ("b="),
+    ("ts="),
     ("load_filter=3"),
     ("load_filter=a"),
     ("load_filter=one"),
+    ("ts_enable=one"),
 
     ("load_filter=0,load_filter="),
     ("load_filter=0,store_filter="),
@@ -140,9 +143,11 @@ def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
     ("load_filter=0,ld="),
     ("load_filter=0,st="),
     ("load_filter=0,b="),
+    ("load_filter=0,ts="),
     ("load_filter=0,load_filter=3"),
     ("load_filter=0,load_filter=a"),
     ("load_filter=0,load_filter=one"),
+    ("ts_enable=1,ts_enable=one"),
 ]
 )
 def test_cpython_bench_spe_cli_incorrect_filter_value(SPE_FILTERS):

--- a/wperf-scripts/tests/wperf_cli_list_test.py
+++ b/wperf-scripts/tests/wperf_cli_list_test.py
@@ -148,3 +148,5 @@ def test_wperf_list_spe_available():
             assert b"[SPE filter]" in line
         if b"branch_filter" in line:
             assert b"[SPE filter]" in line
+        if b"ts_enable" in line:
+            assert b"[SPE filter]" in line

--- a/wperf-test/wperf-test-parsers.cpp
+++ b/wperf-test/wperf-test-parsers.cpp
@@ -113,6 +113,32 @@ namespace wperftest
 			Assert::IsTrue(flags[L"branch_filter"] == false);
 		}
 
+		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_1)
+		{
+			std::wstring events_str = L"arm_spe_0/ts_enable=1/";
+			std::map<std::wstring, bool> flags;
+
+			bool ret = parse_events_str_for_feat_spe(events_str, flags);
+
+			Assert::IsTrue(ret);
+			Assert::IsTrue(flags.size() == 1);
+			Assert::IsTrue(flags.count(L"ts_enable"));
+			Assert::IsTrue(flags[L"ts_enable"] == true);
+		}
+
+		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_0)
+		{
+			std::wstring events_str = L"arm_spe_0/ts_enable=0/";
+			std::map<std::wstring, bool> flags;
+
+			bool ret = parse_events_str_for_feat_spe(events_str, flags);
+
+			Assert::IsTrue(ret);
+			Assert::IsTrue(flags.size() == 1);
+			Assert::IsTrue(flags.count(L"ts_enable"));
+			Assert::IsTrue(flags[L"ts_enable"] == false);
+		}
+
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_10)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1,jitter=0/";
@@ -181,24 +207,27 @@ namespace wperftest
 		* LD enables collection of load sampled operations, including atomic operations that return a value to 
 		  register.
 		* B enables collection of branch sampled operations, including direct and indirect branches and exception
-		  returns.		
+		  returns.
+		* TS enables timestamping with value of generic timer (PMSCR.TS).
 		*/
 
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_010)
 		{
-			std::wstring events_str = L"arm_spe_0/ld=0,st=1,b=0/";
+			std::wstring events_str = L"arm_spe_0/ld=0,st=1,b=0,ts=0/";
 			std::map<std::wstring, bool> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
 			Assert::IsTrue(ret);
-			Assert::IsTrue(flags.size() == 3);
+			Assert::IsTrue(flags.size() == 4);
 			Assert::IsTrue(flags.count(L"ld"));
 			Assert::IsTrue(flags.count(L"st"));
 			Assert::IsTrue(flags.count(L"b"));
+			Assert::IsTrue(flags.count(L"ts"));
 			Assert::IsTrue(flags[L"ld"] == false);
 			Assert::IsTrue(flags[L"st"] == true);
 			Assert::IsTrue(flags[L"b"] == false);
+			Assert::IsTrue(flags[L"ts"] == false);
 		}
 	};
 

--- a/wperf-test/wperf-test-spe_device.cpp
+++ b/wperf-test/wperf-test-spe_device.cpp
@@ -73,6 +73,7 @@ namespace wperftest
 			Assert::IsTrue(spe_device::is_filter_name(L"load_filter"));
 			Assert::IsTrue(spe_device::is_filter_name(L"store_filter"));
 			Assert::IsTrue(spe_device::is_filter_name(L"branch_filter"));
+			Assert::IsTrue(spe_device::is_filter_name(L"ts_enable"));
 		}
 
 		TEST_METHOD(test_spe_device_filter_name_as_alias)
@@ -80,6 +81,7 @@ namespace wperftest
 			Assert::IsTrue(spe_device::is_filter_name(L"ld"));
 			Assert::IsTrue(spe_device::is_filter_name(L"st"));
 			Assert::IsTrue(spe_device::is_filter_name(L"b"));
+			Assert::IsTrue(spe_device::is_filter_name(L"ts"));
 		}
 
 		TEST_METHOD(test_spe_device_filter_name_is_alias)
@@ -87,6 +89,7 @@ namespace wperftest
 			Assert::IsTrue(spe_device::is_filter_name_alias (L"ld"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"st"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"b"));
+			Assert::IsTrue(spe_device::is_filter_name_alias(L"ts"));
 		}
 	};
 }

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -347,16 +347,17 @@ void pmu_device::spe_start(const std::map<std::wstring, bool>& flags)
     ctl.cores_idx.cores_no[0] = cores_idx[0];
     ctl.event_filter = 0;
     UINT8 opfilter = 0;
+    UINT64 config_flags = 0;
     for (const auto& [key, val] : flags)
     {
         if ((key == L"load_filter" || key == L"ld") && val)     opfilter |= SPE_OPERATON_FILTER_LD;
         if ((key == L"store_filter" || key == L"st") && val)    opfilter |= SPE_OPERATON_FILTER_ST;
         if ((key == L"branch_filter" || key == L"b") && val)    opfilter |= SPE_OPERATON_FILTER_B;
-        if ((key == L"ts_enable" || key == L"ts") && val)       opfilter |= SPE_OPERATON_FILTER_TS;
+        if ((key == L"ts_enable" || key == L"ts") && val)       config_flags |= SPE_CTL_FLAG_TS;
     }
     ctl.operation_filter = opfilter;
     ctl.interval = 1024;
-    ctl.config_flags = 0;
+    ctl.config_flags = config_flags;
 
     BOOL status = DeviceAsyncIoControl(m_device_handle, PMU_CTL_SPE_START, &ctl, sizeof(struct spe_ctl_hdr), NULL, 0, &res_len);
     if (!status)

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -352,6 +352,7 @@ void pmu_device::spe_start(const std::map<std::wstring, bool>& flags)
         if ((key == L"load_filter" || key == L"ld") && val)     opfilter |= SPE_OPERATON_FILTER_LD;
         if ((key == L"store_filter" || key == L"st") && val)    opfilter |= SPE_OPERATON_FILTER_ST;
         if ((key == L"branch_filter" || key == L"b") && val)    opfilter |= SPE_OPERATON_FILTER_B;
+        if ((key == L"ts_enable" || key == L"ts") && val)       opfilter |= SPE_OPERATON_FILTER_TS;
     }
     ctl.operation_filter = opfilter;
     ctl.interval = 1024;

--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -405,20 +405,22 @@ namespace SPEParser
 }
 
 const std::vector<std::wstring> spe_device::m_filter_names = {
-        L"load_filter", L"store_filter", L"branch_filter" };
+        L"load_filter", L"store_filter", L"branch_filter", L"ts_enable"};
 
 // Filters also have aliases, this structure helps to translate alias to filter name
 const std::map<std::wstring, std::wstring> spe_device::m_filter_names_aliases = {
     { L"ld", L"load_filter", },
     { L"st", L"store_filter", },
-    { L"b" , L"branch_filter" }
+    { L"b" , L"branch_filter" },
+    { L"ts", L"ts_enable" }
 };
 
 // Filters also have aliases, this structure helps to translate alias to filter name
 const std::map<std::wstring, std::wstring> spe_device::m_filter_names_description = {
     { L"load_filter",   L"Enables collection of load sampled operations, including atomic operations that return a value to a register." },
     { L"store_filter",  L"Enables collection of store sampled operations, including all atomic operations." },
-    { L"branch_filter", L"Enables collection of branch sampled operations, including direct and indirect branches and exception returns." }
+    { L"branch_filter", L"Enables collection of branch sampled operations, including direct and indirect branches and exception returns." },
+    { L"ts_enable",     L"Enables timestamping with value of generic timer." }
 };
 
 spe_device::spe_device() {}


### PR DESCRIPTION
## Description

In this patch I've added new `ts_enable` / `ts` filter to `arm_spe_0//`.

From Linux perf docs:
```
ts_enable=1         - enable timestamping with value of generic timer (PMSCR.TS).
```

### PMSCR_EL1, Statistical Profiling Control Register (EL1

From [Arm Arm](https://developer.arm.com/documentation/ddi0487/latest) ver. K:

`TS, bit [5]`
Timestamp enable.
- `0b0` Timestamp sampling disabled.
- `0b1` Timestamp sampling enabled.

## How Has This Been Tested?

1. Added unit tests for SPE parser: check if new alias and filter is added.
2. I've been using [spe_parser](https://gitlab.arm.com/telemetry-solution/telemetry-solution/-/tree/main/tools/spe_parser) to parse raw SPE fill buffer. I can see TS (timestamp) packets in raw buffer with my `ts_enable` / `ts` filter set to `1` - this is a manual testing.
3. Regression testing (added new tests as well):

```
>pytest
====================================================== test session starts ======================================================
platform win32 -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
configfile: pytest.ini
collected 834 items

wperf_cli_common_test.py ....                                                                                              [  0%]
wperf_cli_config_test.py .....                                                                                             [  1%]
wperf_cli_cpython_bench_test.py .s                                                                                         [  1%]
wperf_cli_cpython_dep_record_spe_test.py .........................................................                         [  8%]
wperf_cli_cpython_dep_record_test.py ...........                                                                           [  9%]
wperf_cli_cpython_dep_sample_test.py .                                                                                     [  9%]
wperf_cli_dmc_test.py .                                                                                                    [  9%]
wperf_cli_dmc_value_test.py .                                                                                              [  9%]
wperf_cli_extra_events_test.py ....                                                                                        [ 10%]
wperf_cli_hammer_core_test.py ..................                                                                           [ 12%]
wperf_cli_help_test.py ..                                                                                                  [ 12%]
wperf_cli_info_str_test.py .                                                                                               [ 12%]
wperf_cli_json_validator_test.py ...............                                                                           [ 14%]
wperf_cli_list_test.py ......                                                                                              [ 15%]
wperf_cli_lock_test.py .....                                                                                               [ 15%]
wperf_cli_man_test.py .................................................................                                    [ 23%]
wperf_cli_man_ts_test.py ................................................................................................. [ 35%]
.............................................................                                                              [ 42%]
wperf_cli_metrics_test.py ........                                                                                         [ 43%]
wperf_cli_metrics_ts_test.py ..........................................................................                    [ 52%]
wperf_cli_padding_test.py ..............                                                                                   [ 54%]
wperf_cli_prettytable_test.py .....                                                                                        [ 54%]
wperf_cli_record_test.py ................s                                                                                 [ 56%]
wperf_cli_sample_test.py ..........                                                                                        [ 58%]
wperf_cli_stat_test.py ......................................................................                              [ 66%]
wperf_cli_stat_value_test.py ............................................................................................. [ 77%]
.......................................................................................                                    [ 88%]
wperf_cli_test_test.py ...........                                                                                         [ 89%]
wperf_cli_timeline_test.py ...............................................                                                 [ 94%]
wperf_cli_ustress_bench_test.py ......                                                                                     [ 95%]
wperf_cli_ustress_dep_record_test.py ..                                                                                    [ 95%]
wperf_cli_ustress_dep_wperf_lib_timeline_test.py .                                                                         [ 96%]
wperf_cli_ustress_dep_wperf_test.py ............                                                                           [ 97%]
wperf_cli_ustress_timeline_test.py ..................                                                                      [ 99%]
wperf_cli_xperf_test.py s                                                                                                  [ 99%]
wperf_lib_app_test.py .                                                                                                    [ 99%]
wperf_lib_c_compat_test.py .                                                                                               [100%]
================================================ WindowsPerf Test Configuration =================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 30/10/2024, 08:39:28
wperf: 3.8.0.9d8d6e90-dirty+etw-app+spe
wperf-driver: 3.8.0.9d8d6e90-dirty+trace+spe

==================================================== short test summary info ====================================================
SKIPPED [1] wperf_cli_cpython_bench_test.py:80: skipping CPython rebuild procedure (already built), cleanup CPython build with 'cpython\PCbuild\clean.bat'
SKIPPED [1] wperf_cli_record_test.py:158: this test is applicable only if `gpc_num` < `total_gpc_num`, now: gpc_num=6 and total_gpc_num=6
SKIPPED [1] wperf_cli_xperf_test.py:64: skipping XPERF test bench, enable it with `--enable-bench-xperf` command line options
========================================== 831 passed, 3 skipped in 2061.31s (0:34:21) ==========================================
```
