### PR TITLE
Remove obsolete doxy config attributes

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1369,15 +1369,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -2037,14 +2028,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,


### PR DESCRIPTION
## Description
Running doxy at the moment prints the following warning message on the screen:

```sh
$ doxygen DoxyFile
warning: Tag 'HTML_TIMESTAMP' at line 1379 of file 'DoxyFile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'LATEX_TIMESTAMP' at line 2047 of file 'DoxyFile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
Doxygen version used: 1.12.0 (c73f5d30f9e8b1df5ba15a1d064ff2067cbb8267)
Searching for include files...
Searching for example files...
Searching for images...
Searching for dot files...
...
...
...
```

I simply removed the tags in question

## Commits
<!-- Commits will be listed automatically when the PR is created -->
${{ github.event.pull_request.commits }}

## How Has This Been Tested?
Running `doxygen DoxyFile` after the changes outputs the documentation without warning

```
$ doxygen DoxyFile
Doxygen version used: 1.12.0 (c73f5d30f9e8b1df5ba15a1d064ff2067cbb8267)
Searching for include files...
Searching for example files...
Searching for images...
Searching for dot files...
...
...
...
```
