### PR TITLE
fix: user_request::check_events comparison logic

### DIFF
--- a/wperf/user_request.cpp
+++ b/wperf/user_request.cpp
@@ -1076,7 +1076,7 @@ void user_request::show_events()
 void user_request::check_events(enum evt_class evt, int max)
 {
     if (ioctl_events.count(evt) &&
-        ioctl_events[evt].size() > MAX_MANAGED_CORE_EVENTS)
+        ioctl_events[evt].size() > max)
     {
         m_out.GetErrorOutputStream() << L"error: too many " << pmu_events::get_evt_class_name(evt) << L" (including padding) events: "
             << ioctl_events[evt].size() << L" > " << max << std::endl;


### PR DESCRIPTION
## Description

This pull request includes a small change to the `wperf/user_request.cpp` file. The change modifies the `user_request::check_events` method to use a dynamic `max` parameter instead of a hardcoded constant for the maximum number of events.

* [`wperf/user_request.cpp`](diffhunk://#diff-e01bdef92ef8f961efe2ae1691b05ae3426af8e57ca4a9a490643205245a6ddcL1079-R1079): Modified the `user_request::check_events` method to compare `ioctl_events[evt].size()` with the `max` parameter instead of the `MAX_MANAGED_CORE_EVENTS` constant.
