### PR TITLE
[wperf] Refactorying before adding new min_latency filter

### DIFF
--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -105,6 +105,9 @@ def test_cpython_bench_spe_cli_incorrect_filter(SPE_FILTERS):
     ("load_filter=10"),
     ("store_filter=0x2"),
     ("branch_filter=0xf1da"),
+    ("b=1,load_filter=10"),
+    ("b=0,store_filter=0x2"),
+    ("b=1,branch_filter=0xf1da"),
 ]
 )
 def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):
@@ -203,8 +206,10 @@ def test_cpython_bench_spe_cli_incorrect_filter_value(SPE_FILTERS):
 
 @pytest.mark.parametrize("EVENT,SPE_FILTERS,HOT_SYMBOL,HOT_MINIMUM,PYTHON_ARG",
 [
-    ("arm_spe_0", "",               "x_mul:python312_d.dll", 65, "10**10**100"),
-    ("arm_spe_0", "load_filter=1",  "x_mul:python312_d.dll", 65, "10**10**100"),
+    ("arm_spe_0", "",                           "x_mul:python312_d.dll", 65, "10**10**100"),
+    ("arm_spe_0", "load_filter=1",              "x_mul:python312_d.dll", 65, "10**10**100"),
+    ("arm_spe_0", "ts_enable=1",                "x_mul:python312_d.dll", 65, "10**10**100"),
+    ("arm_spe_0", "load_filter=1,ts_enable=1",  "x_mul:python312_d.dll", 65, "10**10**100"),
 ]
 )
 def test_cpython_bench_spe_hotspot(EVENT,SPE_FILTERS,HOT_SYMBOL,HOT_MINIMUM,PYTHON_ARG):

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -99,6 +99,31 @@ def test_cpython_bench_spe_cli_incorrect_filter(SPE_FILTERS):
 
 @pytest.mark.parametrize("SPE_FILTERS",
 [
+    ("b=2"),
+    ("ld=3"),
+    ("st=4"),
+    ("load_filter=10"),
+    ("store_filter=0x2"),
+    ("branch_filter=0xf1da"),
+]
+)
+def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):
+    """ Test `wperf record` with SPE CLI filter value
+
+    "SPE filter 'ts_enable' value out of range, use: 0-1"
+
+    """
+    #
+    # Run for CPython payload but we should fail when we hit CLI parser errors
+    #
+    cmd = f"wperf record -e arm_spe_0/{SPE_FILTERS}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
+    _, stderr = run_command(cmd)
+
+    assert b"unexpected arg" not in stderr
+    assert b"value out of range, use:" in stderr
+
+@pytest.mark.parametrize("SPE_FILTERS",
+[
     ("=0"),
     ("=1"),
 
@@ -132,7 +157,6 @@ def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
     ("st="),
     ("b="),
     ("ts="),
-    ("load_filter=3"),
     ("load_filter=a"),
     ("load_filter=one"),
     ("ts_enable=one"),
@@ -144,10 +168,23 @@ def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
     ("load_filter=0,st="),
     ("load_filter=0,b="),
     ("load_filter=0,ts="),
-    ("load_filter=0,load_filter=3"),
     ("load_filter=0,load_filter=a"),
     ("load_filter=0,load_filter=one"),
     ("ts_enable=1,ts_enable=one"),
+
+    ("b=-1"),
+    ("ld=-1"),
+    ("st=-1"),
+    ("load_filter=-10"),
+    ("store_filter=-0x2"),
+    ("branch_filter=-0xf"),
+
+    ("load_filter=0,load_filter=-1"),
+    ("load_filter=0,store_filter=-1"),
+    ("load_filter=0,branch_filter=-1"),
+    ("load_filter=0,ld=-1"),
+    ("load_filter=0,st=-1"),
+    ("load_filter=0,b=-1"),
 ]
 )
 def test_cpython_bench_spe_cli_incorrect_filter_value(SPE_FILTERS):

--- a/wperf-test/wperf-test-parsers.cpp
+++ b/wperf-test/wperf-test-parsers.cpp
@@ -49,7 +49,7 @@ namespace wperftest
 
 		TEST_METHOD(parse_events_str_for_feat_spe_incorrect_input)
 		{
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/"), flags));
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0"), flags));
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_/"), flags));
@@ -63,43 +63,43 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_incorrect_input_throw)
 		{
 			auto wrapper_filter_eq_1 = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/load_filter=-/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_1);
 
 			auto wrapper_filter_eq_2 = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-0x1/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_2);
 
 			auto wrapper_filter_eq_3 = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-2/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_3);
 
 			auto wrapper_filter_eq_4 = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-2/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_4);
 
 			auto wrapper_filter_name_empty = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/=1/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_name_empty);
 
 			auto wrapper_filter_just_eq = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/=/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_just_eq);
 
 			auto wrapper_filter_eq_letter = [=]() {
-				std::map<std::wstring, uint32_t> flags;
+				std::map<std::wstring, uint64_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/jitter=x/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_letter);
@@ -108,7 +108,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_branch_filter_1)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -121,7 +121,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_branch_filter_0)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -134,7 +134,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_1)
 		{
 			std::wstring events_str = L"arm_spe_0/ts_enable=1/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -147,7 +147,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_0)
 		{
 			std::wstring events_str = L"arm_spe_0/ts_enable=0/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -160,7 +160,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_10)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1,jitter=0/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -175,7 +175,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_01)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0,jitter=1/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -190,7 +190,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_11)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1,jitter=1/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -205,7 +205,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_00)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0,jitter=0/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -220,7 +220,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_min_latency)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0,min_latency=10/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			Assert::IsTrue(parse_events_str_for_feat_spe(events_str, flags));
 			Assert::IsTrue(flags.size() == 2);
@@ -233,7 +233,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_3_filters_00)
 		{
 			std::wstring events_str = L"arm_spe_0/abc=0,def=10,ghi=0x11f/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			Assert::IsTrue(parse_events_str_for_feat_spe(events_str, flags));
 			Assert::IsTrue(flags.size() == 3);
@@ -260,7 +260,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_010)
 		{
 			std::wstring events_str = L"arm_spe_0/ld=0,st=1,b=0,ts=0/";
-			std::map<std::wstring, uint32_t> flags;
+			std::map<std::wstring, uint64_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 

--- a/wperf-test/wperf-test-parsers.cpp
+++ b/wperf-test/wperf-test-parsers.cpp
@@ -49,7 +49,7 @@ namespace wperftest
 
 		TEST_METHOD(parse_events_str_for_feat_spe_incorrect_input)
 		{
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/"), flags));
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0"), flags));
 			Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_/"), flags));
@@ -63,25 +63,25 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_incorrect_input_throw)
 		{
 			auto wrapper_filter_eq_2 = [=]() {
-				std::map<std::wstring, bool> flags;
+				std::map<std::wstring, uint32_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=2/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_2);
 
 			auto wrapper_filter_name_empty = [=]() {
-				std::map<std::wstring, bool> flags;
+				std::map<std::wstring, uint32_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/=1/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_name_empty);
 
 			auto wrapper_filter_just_eq = [=]() {
-				std::map<std::wstring, bool> flags;
+				std::map<std::wstring, uint32_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/=/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_just_eq);
 
 			auto wrapper_filter_eq_letter = [=]() {
-				std::map<std::wstring, bool> flags;
+				std::map<std::wstring, uint32_t> flags;
 				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/jitter=x/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_letter);
@@ -90,59 +90,59 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_branch_filter_1)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
 			Assert::IsTrue(ret);
 			Assert::IsTrue(flags.size() == 1);
 			Assert::IsTrue(flags.count(L"branch_filter"));
-			Assert::IsTrue(flags[L"branch_filter"] == true);
+			Assert::IsTrue(flags[L"branch_filter"] == 1);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_branch_filter_0)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
 			Assert::IsTrue(ret);
 			Assert::IsTrue(flags.size() == 1);
 			Assert::IsTrue(flags.count(L"branch_filter"));
-			Assert::IsTrue(flags[L"branch_filter"] == false);
+			Assert::IsTrue(flags[L"branch_filter"] == 0);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_1)
 		{
 			std::wstring events_str = L"arm_spe_0/ts_enable=1/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
 			Assert::IsTrue(ret);
 			Assert::IsTrue(flags.size() == 1);
 			Assert::IsTrue(flags.count(L"ts_enable"));
-			Assert::IsTrue(flags[L"ts_enable"] == true);
+			Assert::IsTrue(flags[L"ts_enable"] == 1);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_ts_enable_0)
 		{
 			std::wstring events_str = L"arm_spe_0/ts_enable=0/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
 			Assert::IsTrue(ret);
 			Assert::IsTrue(flags.size() == 1);
 			Assert::IsTrue(flags.count(L"ts_enable"));
-			Assert::IsTrue(flags[L"ts_enable"] == false);
+			Assert::IsTrue(flags[L"ts_enable"] == 0);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_10)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1,jitter=0/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -150,14 +150,14 @@ namespace wperftest
 			Assert::IsTrue(flags.size() == 2);
 			Assert::IsTrue(flags.count(L"branch_filter"));
 			Assert::IsTrue(flags.count(L"jitter"));
-			Assert::IsTrue(flags[L"branch_filter"] == true);
-			Assert::IsTrue(flags[L"jitter"] == false);
+			Assert::IsTrue(flags[L"branch_filter"] == 1);
+			Assert::IsTrue(flags[L"jitter"] == 0);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_01)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0,jitter=1/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -165,14 +165,14 @@ namespace wperftest
 			Assert::IsTrue(flags.size() == 2);
 			Assert::IsTrue(flags.count(L"branch_filter"));
 			Assert::IsTrue(flags.count(L"jitter"));
-			Assert::IsTrue(flags[L"branch_filter"] == false);
-			Assert::IsTrue(flags[L"jitter"] == true);
+			Assert::IsTrue(flags[L"branch_filter"] == 0);
+			Assert::IsTrue(flags[L"jitter"] == 1);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_11)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=1,jitter=1/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -180,14 +180,14 @@ namespace wperftest
 			Assert::IsTrue(flags.size() == 2);
 			Assert::IsTrue(flags.count(L"branch_filter"));
 			Assert::IsTrue(flags.count(L"jitter"));
-			Assert::IsTrue(flags[L"branch_filter"] == true);
-			Assert::IsTrue(flags[L"jitter"] == true);
+			Assert::IsTrue(flags[L"branch_filter"] == 1);
+			Assert::IsTrue(flags[L"jitter"] == 1);
 		}
 
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_00)
 		{
 			std::wstring events_str = L"arm_spe_0/branch_filter=0,jitter=0/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -195,8 +195,8 @@ namespace wperftest
 			Assert::IsTrue(flags.size() == 2);
 			Assert::IsTrue(flags.count(L"branch_filter"));
 			Assert::IsTrue(flags.count(L"jitter"));
-			Assert::IsTrue(flags[L"branch_filter"] == false);
-			Assert::IsTrue(flags[L"jitter"] == false);
+			Assert::IsTrue(flags[L"branch_filter"] == 0);
+			Assert::IsTrue(flags[L"jitter"] == 0);
 		}
 
 		/* Example usage could include:
@@ -214,7 +214,7 @@ namespace wperftest
 		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_010)
 		{
 			std::wstring events_str = L"arm_spe_0/ld=0,st=1,b=0,ts=0/";
-			std::map<std::wstring, bool> flags;
+			std::map<std::wstring, uint32_t> flags;
 
 			bool ret = parse_events_str_for_feat_spe(events_str, flags);
 
@@ -224,10 +224,10 @@ namespace wperftest
 			Assert::IsTrue(flags.count(L"st"));
 			Assert::IsTrue(flags.count(L"b"));
 			Assert::IsTrue(flags.count(L"ts"));
-			Assert::IsTrue(flags[L"ld"] == false);
-			Assert::IsTrue(flags[L"st"] == true);
-			Assert::IsTrue(flags[L"b"] == false);
-			Assert::IsTrue(flags[L"ts"] == false);
+			Assert::IsTrue(flags[L"ld"] == 0);
+			Assert::IsTrue(flags[L"st"] == 1);
+			Assert::IsTrue(flags[L"b"] == 0);
+			Assert::IsTrue(flags[L"ts"] == 0);
 		}
 	};
 

--- a/wperf-test/wperf-test-parsers.cpp
+++ b/wperf-test/wperf-test-parsers.cpp
@@ -62,11 +62,29 @@ namespace wperftest
 
 		TEST_METHOD(parse_events_str_for_feat_spe_incorrect_input_throw)
 		{
+			auto wrapper_filter_eq_1 = [=]() {
+				std::map<std::wstring, uint32_t> flags;
+				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/load_filter=-/"), flags));
+				};
+			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_1);
+
 			auto wrapper_filter_eq_2 = [=]() {
 				std::map<std::wstring, uint32_t> flags;
-				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=2/"), flags));
+				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-0x1/"), flags));
 				};
 			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_2);
+
+			auto wrapper_filter_eq_3 = [=]() {
+				std::map<std::wstring, uint32_t> flags;
+				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-2/"), flags));
+				};
+			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_3);
+
+			auto wrapper_filter_eq_4 = [=]() {
+				std::map<std::wstring, uint32_t> flags;
+				Assert::IsFalse(parse_events_str_for_feat_spe(std::wstring(L"arm_spe_0/branch_filter=-2/"), flags));
+				};
+			Assert::ExpectException<fatal_exception>(wrapper_filter_eq_4);
 
 			auto wrapper_filter_name_empty = [=]() {
 				std::map<std::wstring, uint32_t> flags;
@@ -197,6 +215,34 @@ namespace wperftest
 			Assert::IsTrue(flags.count(L"jitter"));
 			Assert::IsTrue(flags[L"branch_filter"] == 0);
 			Assert::IsTrue(flags[L"jitter"] == 0);
+		}
+
+		TEST_METHOD(parse_events_str_for_feat_spe_2_filters_min_latency)
+		{
+			std::wstring events_str = L"arm_spe_0/branch_filter=0,min_latency=10/";
+			std::map<std::wstring, uint32_t> flags;
+
+			Assert::IsTrue(parse_events_str_for_feat_spe(events_str, flags));
+			Assert::IsTrue(flags.size() == 2);
+			Assert::IsTrue(flags.count(L"branch_filter"));
+			Assert::IsTrue(flags.count(L"min_latency"));
+			Assert::IsTrue(flags[L"branch_filter"] == 0);
+			Assert::IsTrue(flags[L"min_latency"] == 10);
+		}
+
+		TEST_METHOD(parse_events_str_for_feat_spe_3_filters_00)
+		{
+			std::wstring events_str = L"arm_spe_0/abc=0,def=10,ghi=0x11f/";
+			std::map<std::wstring, uint32_t> flags;
+
+			Assert::IsTrue(parse_events_str_for_feat_spe(events_str, flags));
+			Assert::IsTrue(flags.size() == 3);
+			Assert::IsTrue(flags.count(L"abc"));
+			Assert::IsTrue(flags.count(L"def"));
+			Assert::IsTrue(flags.count(L"ghi"));
+			Assert::IsTrue(flags[L"abc"] == 0);
+			Assert::IsTrue(flags[L"def"] == 10);
+			Assert::IsTrue(flags[L"ghi"] == 0x11f);
 		}
 
 		/* Example usage could include:

--- a/wperf-test/wperf-test-utils.cpp
+++ b/wperf-test/wperf-test-utils.cpp
@@ -1212,5 +1212,121 @@ namespace wperftest
 			Assert::AreEqual(ConvertNumberWithUnit(double(60), std::wstring(L"d"), unitMap), double(5184000));
 			Assert::AreEqual(ConvertNumberWithUnit(double(2.5), std::wstring(L"h"), unitMap), double(9000));
 		}
+
+		TEST_METHOD(test_ConvertWStringToInt_type_uint32_t)
+		{
+			uint32_t value;
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"1"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"32"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"1025"), value, 0));
+
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0x00"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0x10"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0xFAFAFA"), value, 0));
+		}
+
+		TEST_METHOD(test_ConvertWStringToInt_value_uint32_t)
+		{
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"0"), value, 0);
+				Assert::IsTrue(value == 0);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"0x00"), value, 0);
+				Assert::IsTrue(value == 0);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"1"), value, 0);
+				Assert::IsTrue(value == 1);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"0x1"), value, 0);
+				Assert::IsTrue(value == 0x1);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"0x16"), value, 0);
+				Assert::IsTrue(value == 0x16);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"0xaF12D"), value, 0);
+				Assert::IsTrue(value == 0xAF12D);
+			}
+
+			{
+				uint32_t value;
+				ConvertWStringToInt(std::wstring(L"7919"), value, 0);
+				Assert::IsTrue(value == 7919);
+			}
+		}
+
+		TEST_METHOD(test_ConvertWStringToInt_type_uint64_t)
+		{
+			uint64_t value;
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"1"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"32"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"1025"), value, 0));
+
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0x00"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0x10"), value, 0));
+			Assert::IsTrue(ConvertWStringToInt(std::wstring(L"0xDEADBEAF"), value, 0));
+		}
+
+		TEST_METHOD(test_ConvertWStringToInt_value_uint64_t)
+		{
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"0"), value, 0);
+				Assert::IsTrue(value == 0);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"0x00"), value, 0);
+				Assert::IsTrue(value == 0);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"1"), value, 0);
+				Assert::IsTrue(value == 1);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"0x1"), value, 0);
+				Assert::IsTrue(value == 0x1);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"0x16"), value, 0);
+				Assert::IsTrue(value == 0x16);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"0xaF12D"), value, 0);
+				Assert::IsTrue(value == 0xAF12D);
+			}
+
+			{
+				uint64_t value;
+				ConvertWStringToInt(std::wstring(L"7919"), value, 0);
+				Assert::IsTrue(value == 7919);
+			}
+		}
 	};
 }

--- a/wperf/README.md
+++ b/wperf/README.md
@@ -1767,7 +1767,7 @@ If `FeatureString` for both components (`wperf` and `wperf-driver`) contains `+s
 
 ### arm_spe_0// format
 
-Users can specify SPE filters using the `-e` command line option with `arm_spe_0//`. We've introduced the `arm_spe_0/*/` notation for the `record` command, where `*` represents a comma-separated list of supported filters. Currently, we support filters such as `store_filter=`, `load_filter=`, and `branch_filter=`, or their short equivalents like `st=`, `ld=`, and `b=`. Use `0` or `1` to disable or enable a given filter. For example:
+Users can specify SPE filters using the `-e` command line option with `arm_spe_0//`. We've introduced the `arm_spe_0/*/` notation for the `record` command, where `*` represents a comma-separated list of supported filters. Currently, we support filters such as `store_filter=`, `load_filter=`, `branch_filter=` and `ts_enable=`, or their short equivalents like `st=`, `ld=`, `b=` and `ts=`. Use `0` or `1` to disable or enable a given filter. For example:
 
 ```
 arm_spe_0/branch_filter=1/
@@ -1775,6 +1775,13 @@ arm_spe_0/load_filter=1,branch_filter=0/
 arm_spe_0/ld=1,branch_filter=0/
 arm_spe_0/st=0,ld=0,b=1/
 ```
+
+### List of supported SPE filters
+
+- `branch_filter=1`- collect branches only.
+- `load_filter=1` - collect loads only.
+- `store_filter=1` - collect stores only.
+- `ts_enable=1` - enable timestamping with value of generic timer.
 
 #### Filtering sample records
 

--- a/wperf/parsers.cpp
+++ b/wperf/parsers.cpp
@@ -174,7 +174,7 @@ void parse_events_extra(std::wstring events_str, std::map<enum evt_class, std::v
     $ perf record -e arm_spe/branch_filter=1,jitter=1/ -- workload
     $ perf record -e spe/branch_filter=1,jitter=1/ -- workload
 */
-bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint32_t>& flags)
+bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint64_t>& flags)
 {
     // Detect arm_spe_0/*/      - where '*'
     if (events_str.size() >= std::wstring(L"arm_spe_0//").size()

--- a/wperf/parsers.cpp
+++ b/wperf/parsers.cpp
@@ -204,13 +204,16 @@ bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstrin
                 throw fatal_exception("ERROR_SPE_FILTER_NAME");
             }
 
-            if (filter_value != L"0" && filter_value != L"1")
+            int32_t value = 0;
+            if (ConvertWStringToInt(filter_value, value, 0) == false
+                || value < 0
+                || value > std::numeric_limits<int32_t>::max())
             {
-                m_out.GetErrorOutputStream() << L"incorrect SPE filter value: " << L"'" << filter << L"'. 0 or 1 allowed" << std::endl;
+                m_out.GetErrorOutputStream() << L"incorrect SPE filter value: " << filter_name << L"='" << filter << L"'." << std::endl;
                 throw fatal_exception("ERROR_SPE_FILTER_VALUE");
             }
 
-            flags[filter_name] = true ? filter_value == L"1" : false;
+            flags[filter_name] = static_cast<uint32_t>(value);
         }
 
         return true;

--- a/wperf/parsers.cpp
+++ b/wperf/parsers.cpp
@@ -209,7 +209,7 @@ bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstrin
                 || value < 0
                 || value > std::numeric_limits<int32_t>::max())
             {
-                m_out.GetErrorOutputStream() << L"incorrect SPE filter value: " << filter_name << L"='" << filter << L"'." << std::endl;
+                m_out.GetErrorOutputStream() << L"incorrect SPE filter value: " << filter_name << L"='" << filter_value << L"'." << std::endl;
                 throw fatal_exception("ERROR_SPE_FILTER_VALUE");
             }
 

--- a/wperf/parsers.cpp
+++ b/wperf/parsers.cpp
@@ -174,7 +174,7 @@ void parse_events_extra(std::wstring events_str, std::map<enum evt_class, std::v
     $ perf record -e arm_spe/branch_filter=1,jitter=1/ -- workload
     $ perf record -e spe/branch_filter=1,jitter=1/ -- workload
 */
-bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring, bool>& flags)
+bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint32_t>& flags)
 {
     // Detect arm_spe_0/*/      - where '*'
     if (events_str.size() >= std::wstring(L"arm_spe_0//").size()

--- a/wperf/parsers.h
+++ b/wperf/parsers.h
@@ -40,7 +40,7 @@ inline constexpr uint32_t PARSE_INTERVAL_DEFAULT = 0x4000000;
 
 void parse_events_extra(std::wstring events_str, std::map<enum evt_class, std::vector<struct extra_event>>& events);
 
-bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint32_t>& flags);
+bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring, uint64_t>& flags);
 
 void parse_events_str_for_sample(std::wstring events_str,
     std::vector<struct evt_sample_src>& ioctl_events_sample,

--- a/wperf/parsers.h
+++ b/wperf/parsers.h
@@ -40,8 +40,7 @@ inline constexpr uint32_t PARSE_INTERVAL_DEFAULT = 0x4000000;
 
 void parse_events_extra(std::wstring events_str, std::map<enum evt_class, std::vector<struct extra_event>>& events);
 
-bool parse_events_str_for_feat_spe(std::wstring events_str,
-    std::map<std::wstring, bool>& flags);
+bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint32_t>& flags);
 
 void parse_events_str_for_sample(std::wstring events_str,
     std::vector<struct evt_sample_src>& ioctl_events_sample,

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -336,7 +336,7 @@ bool pmu_device::spe_get()
     return m_spe_size_to_copy > 0;
 }
 
-void pmu_device::spe_start(const std::map<std::wstring, uint32_t>& flags)
+void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
 {
     if (!m_has_spe) return;
 

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -336,7 +336,7 @@ bool pmu_device::spe_get()
     return m_spe_size_to_copy > 0;
 }
 
-void pmu_device::spe_start(const std::map<std::wstring, bool>& flags)
+void pmu_device::spe_start(const std::map<std::wstring, uint32_t>& flags)
 {
     if (!m_has_spe) return;
 

--- a/wperf/pmu_device.h
+++ b/wperf/pmu_device.h
@@ -125,7 +125,7 @@ public:
 
     // SPE
     void spe_init();
-    void spe_start(const std::map<std::wstring, bool>& flags);
+    void spe_start(const std::map<std::wstring, uint32_t>& flags);
     void spe_stop();
     bool spe_get();
     void pmu_device::spe_print_core_stats(std::vector<struct evt_noted>& events);
@@ -247,7 +247,7 @@ public:
 
     // SPE
     bool m_sampling_with_spe = false;                   // SPE: User requested sampling with SPE
-    std::map<std::wstring, bool> m_sampling_flags;      // SPE: sampling flags
+    std::map<std::wstring, uint32_t> m_sampling_flags;      // SPE: sampling flags
     std::wstring get_spe_version_name();                // SPE: get SPE feature exact version based on HW detection
 
     uint8_t gpc_nums[EVT_CLASS_NUM];

--- a/wperf/pmu_device.h
+++ b/wperf/pmu_device.h
@@ -125,7 +125,7 @@ public:
 
     // SPE
     void spe_init();
-    void spe_start(const std::map<std::wstring, uint32_t>& flags);
+    void spe_start(const std::map<std::wstring, uint64_t>& flags);
     void spe_stop();
     bool spe_get();
     void pmu_device::spe_print_core_stats(std::vector<struct evt_noted>& events);
@@ -247,7 +247,7 @@ public:
 
     // SPE
     bool m_sampling_with_spe = false;                   // SPE: User requested sampling with SPE
-    std::map<std::wstring, uint32_t> m_sampling_flags;      // SPE: sampling flags
+    std::map<std::wstring, uint64_t> m_sampling_flags;      // SPE: sampling flags
     std::wstring get_spe_version_name();                // SPE: get SPE feature exact version based on HW detection
 
     uint8_t gpc_nums[EVT_CLASS_NUM];

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -73,7 +73,7 @@ public:
         return m_filter_names_aliases.count(fname);
     }
 
-    static uint32_t max_filter_val(std::wstring fname)
+    static uint64_t max_filter_val(std::wstring fname)
     {
         if (CaseInsensitiveWStringComparision(fname, L"min_latency"))
             return 0xFFFF;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -30,11 +30,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <windows.h>
+#include <vector>
+#include <map>
 #include <string>
 #include "wperf-common/macros.h"
 #include "wperf-common/iorequest.h"
-#include <vector>
-#include <map>
+#include "utils.h"
+
 
 class spe_device
 {
@@ -69,5 +71,12 @@ public:
 
     static bool is_filter_name_alias(std::wstring fname) {
         return m_filter_names_aliases.count(fname);
+    }
+
+    static uint32_t max_filter_val(std::wstring fname)
+    {
+        if (CaseInsensitiveWStringComparision(fname, L"min_latency"))
+            return 0xFFFF;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
+        return 1;
     }
 };

--- a/wperf/user_request.cpp
+++ b/wperf/user_request.cpp
@@ -506,6 +506,14 @@ void user_request::parse_raw_args(wstr_vec& raw_args, const struct pmu_device_cf
                                 << std::endl;
                             throw fatal_exception("ERROR_SPE_FILTER_ERR");
                         }
+
+                        if (spe_device::max_filter_val(key) > value)
+                        {
+                            m_out.GetErrorOutputStream() << L"SPE filter '" << key << L"' value out of range, use: 0-"
+                                << spe_device::max_filter_val(key)
+                                << std::endl;
+                            throw fatal_exception("ERROR_SPE_FILTER_ERR");
+                        }
                     }
 
                     /* When the user requests SPE we always include hidden events for the PMU. This 

--- a/wperf/user_request.cpp
+++ b/wperf/user_request.cpp
@@ -507,7 +507,7 @@ void user_request::parse_raw_args(wstr_vec& raw_args, const struct pmu_device_cf
                             throw fatal_exception("ERROR_SPE_FILTER_ERR");
                         }
 
-                        if (spe_device::max_filter_val(key) > value)
+                        if (value > spe_device::max_filter_val(key))
                         {
                             m_out.GetErrorOutputStream() << L"SPE filter '" << key << L"' value out of range, use: 0-"
                                 << spe_device::max_filter_val(key)

--- a/wperf/user_request.h
+++ b/wperf/user_request.h
@@ -115,7 +115,7 @@ public:
     std::map<std::wstring, metric_desc> metrics;
     std::map<uint32_t, uint32_t> sampling_inverval;     //!< [event_index] -> event_sampling_interval
     bool m_sampling_with_spe = false;                   // SPE: User requested sampling with SPE
-    std::map<std::wstring, bool> m_sampling_flags;      // SPE: sampling flags
+    std::map<std::wstring, uint32_t> m_sampling_flags;      // SPE: sampling flags
 
 private:
     bool all_cores_p() const {

--- a/wperf/user_request.h
+++ b/wperf/user_request.h
@@ -115,7 +115,7 @@ public:
     std::map<std::wstring, metric_desc> metrics;
     std::map<uint32_t, uint32_t> sampling_inverval;     //!< [event_index] -> event_sampling_interval
     bool m_sampling_with_spe = false;                   // SPE: User requested sampling with SPE
-    std::map<std::wstring, uint32_t> m_sampling_flags;      // SPE: sampling flags
+    std::map<std::wstring, uint64_t> m_sampling_flags;      // SPE: sampling flags
 
 private:
     bool all_cores_p() const {

--- a/wperf/utils.h
+++ b/wperf/utils.h
@@ -60,6 +60,38 @@ void ReplaceAllTokensInWString(std::wstring& str, const std::wstring& old_token,
 std::wstring GetFullFilePath(std::wstring dir_str, std::wstring filename_str);
 
 /// <summary>
+/// Convert WSTRING to (unsigned) long long.
+/// </summary>
+/// <param name="input">WSTRING to parse</param>
+/// <param name="output">Value conveted to (U)LL</param>
+/// <param name="base">std::stoll//stoull base parameter</param>
+template<typename T>
+bool ConvertWStringToInt(std::wstring input, T& output, int base = 0)
+{
+    static_assert(std::is_integral<T>::value, "Integral type required in output<T>");
+
+    try
+    {
+        std::size_t pos = 0;
+        if (std::is_unsigned_v<T>)
+            output = static_cast<T>(std::stoull(input, &pos, base));
+        else
+            output = static_cast<T>(std::stoll(input, &pos, base));
+    }
+    catch (std::invalid_argument const&)
+    {
+        return false;
+    }
+    catch (std::out_of_range const&)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+
+/// <summary>
 /// Converts integer VALUE to decimal WSTRING, e.g. 123 -> "123"
 /// </summary>
 /// <param name="Value">Value to convert to hex string</param>


### PR DESCRIPTION
## Description

This PR introduces several improvements and updates related to SPE (Statistical Profiling Extension) filter handling and wperf scripts.

Example SPE filters can take not only values 0,1 but also integer (in base 10 and hex) as an input. For example `-e arm_spe/load_filter=1,min_latency=10/`:

- `branch_filter=1`     - collect branches only (PMSFCR.B)
- `event_filter=<mask>` - filter on specific events (PMSEVFR) - see bitfield description below
- `jitter=1`            - use jitter to avoid resonance when sampling (PMSIRR.RND)
- `load_filter=1`       - collect loads only (PMSFCR.LD)
- `min_latency=<n>`     - collect only samples with this latency or higher* (PMSLATFR)
- `pa_enable=1`         - collect physical address (as well as VA) of loads/stores (PMSCR.PA) - requires privilege
- `pct_enable=1`        - collect physical timestamp instead of virtual timestamp (PMSCR.PCT) - requires privilege
- `store_filter=1`      - collect stores only (PMSFCR.ST)
- `ts_enable=1`         - enable timestamping with value of generic timer (PMSCR.TS)


## Changelog
- Fixed the check for max filter value in `user_request::parse_raw_args()`.
- Bumped SPE filter flags value from `uint32_t` to `uint64_t` to accommodate larger values.
- Added `spe_device::max_filter_val()` function to check the maximum filter value (Commit: 916c135).
- Updated `parse_events_str_for_feat_spe()` to allow unsigned integers as filter input.
- Added `ConvertWStringToInt()` utility function.
- Updated `wperf_cli_cpython_dep_record_spe_test.py` to align with new SPE parser properties.

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.

```
>pytest
====================================================== test session starts ======================================================
platform win32 -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
configfile: pytest.ini
collected 852 items

wperf_cli_common_test.py ....                                                                                              [  0%]
wperf_cli_config_test.py .....                                                                                             [  1%]
wperf_cli_cpython_bench_test.py .s                                                                                         [  1%]
wperf_cli_cpython_dep_record_spe_test.py ...........................................................................       [ 10%]
wperf_cli_cpython_dep_record_test.py ...........                                                                           [ 11%]
wperf_cli_cpython_dep_sample_test.py .                                                                                     [ 11%]
wperf_cli_dmc_test.py .                                                                                                    [ 11%]
wperf_cli_dmc_value_test.py .                                                                                              [ 11%]
wperf_cli_extra_events_test.py ....                                                                                        [ 12%]
wperf_cli_hammer_core_test.py ..................                                                                           [ 14%]
wperf_cli_help_test.py ..                                                                                                  [ 14%]
wperf_cli_info_str_test.py .                                                                                               [ 14%]
wperf_cli_json_validator_test.py ...............                                                                           [ 16%]
wperf_cli_list_test.py ......                                                                                              [ 17%]
wperf_cli_lock_test.py .....                                                                                               [ 17%]
wperf_cli_man_test.py .................................................................                                    [ 25%]
wperf_cli_man_ts_test.py ................................................................................................. [ 36%]
.............................................................                                                              [ 43%]
wperf_cli_metrics_test.py ........                                                                                         [ 44%]
wperf_cli_metrics_ts_test.py ..........................................................................                    [ 53%]
wperf_cli_padding_test.py ..............                                                                                   [ 55%]
wperf_cli_prettytable_test.py .....                                                                                        [ 55%]
wperf_cli_record_test.py ................s                                                                                 [ 57%]
wperf_cli_sample_test.py ..........                                                                                        [ 58%]
wperf_cli_stat_test.py ......................................................................                              [ 67%]
wperf_cli_stat_value_test.py ............................................................................................. [ 78%]
.......................................................................................                                    [ 88%]
wperf_cli_test_test.py ...........                                                                                         [ 89%]
wperf_cli_timeline_test.py ...............................................                                                 [ 95%]
wperf_cli_ustress_bench_test.py ......                                                                                     [ 95%]
wperf_cli_ustress_dep_record_test.py ..                                                                                    [ 96%]
wperf_cli_ustress_dep_wperf_lib_timeline_test.py .                                                                         [ 96%]
wperf_cli_ustress_dep_wperf_test.py ............                                                                           [ 97%]
wperf_cli_ustress_timeline_test.py ..................                                                                      [ 99%]
wperf_cli_xperf_test.py s                                                                                                  [ 99%]
wperf_lib_app_test.py .                                                                                                    [ 99%]
wperf_lib_c_compat_test.py .                                                                                               [100%]
================================================ WindowsPerf Test Configuration =================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 04/11/2024, 07:15:15
wperf: 3.8.0.5a19a488-dirty+etw-app+spe
wperf-driver: 3.8.0.9d8d6e90-dirty+trace+spe

==================================================== short test summary info ====================================================
SKIPPED [1] wperf_cli_cpython_bench_test.py:80: skipping CPython rebuild procedure (already built), cleanup CPython build with 'cpython\PCbuild\clean.bat'
SKIPPED [1] wperf_cli_record_test.py:158: this test is applicable only if `gpc_num` < `total_gpc_num`, now: gpc_num=6 and total_gpc_num=6
SKIPPED [1] wperf_cli_xperf_test.py:64: skipping XPERF test bench, enable it with `--enable-bench-xperf` command line options
========================================== 849 passed, 3 skipped in 2106.11s (0:35:06) ==========================================
```
