### PR TITLE
[wperf] Add (in verbose mode / -v) prints for PCs and symbols discovered

### DIFF
--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -860,6 +860,7 @@ wmain(
                         if (request.do_verbose)
                             m_out.GetOutputStream() << "symbol found:\t"
                                 << std::hex
+                                    << L"\t" << L"0x" << (b.offset + sec_base)
                                     << L"\t" << L"0x" << sd.desc.sec_idx
                                     << L"\t" << L"0x" << sd.desc.offset
                                     << L"\t" << L"0x" << sd.desc.size
@@ -909,6 +910,7 @@ wmain(
                                     if (request.do_verbose)
                                         m_out.GetOutputStream() << "symbol found:\t"
                                             << std::hex
+                                                << L"\t" << L"0x" << (b.offset + sec_base)
                                                 << L"\t" << L"0x" << sd.desc.sec_idx
                                                 << L"\t" << L"0x" << sd.desc.offset
                                                 << L"\t" << L"0x" << sd.desc.size
@@ -1099,10 +1101,9 @@ wmain(
                 if (request.do_verbose)
                 {
                     std::sort(a.pc.begin(), a.pc.end(), sort_pcs);
-
-                    for (int i = 0; i < 10 && i < a.pc.size(); i++)
+                    for (int i = 0; i < a.pc.size(); i++)
                     {
-                        m_out.GetOutputStream() << L"                   " << IntToHexWideString(a.pc[i].first, 20) << L" " << IntToDecWideString(a.pc[i].second, 8) << std::endl;
+                        m_out.GetOutputStream() << L"pc:\t" << IntToHexWideString(a.pc[i].first, 20) << L"\t" << IntToDecWideString(a.pc[i].second, 8) << std::endl;
                         col_pcs.push_back(a.pc[i].first);
                         col_pcs_count.push_back(a.pc[i].second);
                     }

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -857,6 +857,14 @@ wmain(
                         sd.desc = b;
                         sd.module = 0;
                         found = true;
+                        if (request.do_verbose)
+                            m_out.GetOutputStream() << "symbol found:\t"
+                                << std::hex
+                                    << L"\t" << L"0x" << sd.desc.sec_idx
+                                    << L"\t" << L"0x" << sd.desc.offset
+                                    << L"\t" << L"0x" << sd.desc.size
+                            << L"\t" << sd.desc.sname << L"\t" << sd.desc.name
+                            << std::endl;
                         break;
                     }
                 }
@@ -898,6 +906,14 @@ wmain(
                                     sd.desc.sname = b.name;
                                     sd.module = &mmd;
                                     found = true;
+                                    if (request.do_verbose)
+                                        m_out.GetOutputStream() << "symbol found:\t"
+                                            << std::hex
+                                                << L"\t" << L"0x" << sd.desc.sec_idx
+                                                << L"\t" << L"0x" << sd.desc.offset
+                                                << L"\t" << L"0x" << sd.desc.size
+                                        << L"\t" << sd.desc.sname << L"\t" << sd.desc.name
+                                        << L"\t" << sd.module->mod_name << std::endl;
                                     break;
                                 }
                         }


### PR DESCRIPTION
## Description

In this patch I've added one new print of all discovered symbols in verbose mode. Also updated how we print PCs for the sample, now we print all PCs.

### New print of all discovered symbols

```
Sampling stopped, process pid=12276 exited with code 0xc000013a
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbcbd310  0x1     0x16c310        0x14c   _Py_atomic_load_32bit_impl      _Py_atomic_load_32bit_impl:python312_d.dll      python312_d.dll
symbol found:           0x7ffdbbf52e20  0x1     0x401e20        0x2b8   x_add   x_add:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf52978  0x1     0x401978        0x190   v_isub  v_isub:python312_d.dll  python312_d.dll
symbol found:           0x7ffdbbf52710  0x1     0x401710        0x1e8   v_iadd  v_iadd:python312_d.dll  python312_d.dll
symbol found:           0x7ffdbbf52978  0x1     0x401978        0x190   v_isub  v_isub:python312_d.dll  python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf54038  0x1     0x403038        0x738   x_mul   x_mul:python312_d.dll   python312_d.dll
symbol found:           0x7ffdbbf52978  0x1     0x401978        0x190   v_isub  v_isub:python312_d.dll  python312_d.dll
symbol found:           0x7ffdbbf836b8  0x1     0x4326b8        0x90    read_size_t     read_size_t:python312_d.dll     python312_d.dll
```

### Updated how we print PCs (we now print all) for symbols found:

```
======================== sample source: OTHER/retired, top 50 hot functions ========================
pc:     0x000000007ffdbbf54388         2
pc:     0x000000007ffdbbf543cc         1
pc:     0x000000007ffdbbf543c0         1
pc:     0x000000007ffdbbf543a4         1
pc:     0x000000007ffdbbf543ac         1
pc:     0x000000007ffdbbf543d4         1
pc:     0x000000007ffdbbf543b0         1
pc:     0x000000007ffdbbf52a58         2
pc:     0x000000007ffdbbf52a18         1
pc:     0x000000007ffdbbcbd320         1
pc:     0x000000007ffdbbf52fe8         1
pc:     0x000000007ffdbbf83730         1
        overhead  count  symbol
        ========  =====  ======
           57.14      8  x_mul:python312_d.dll
           21.43      3  v_isub:python312_d.dll
            7.14      1  _Py_atomic_load_32bit_impl:python312_d.dll
            7.14      1  x_add:python312_d.dll
            7.14      1  read_size_t:python312_d.dll
          100.00%    14  top 5 in total
```
