### PR TITLE
[wperf-driver,wperf] [SPE] Add minimum Latency filter `min_latency=<n>` to arm_spe_0//

### DIFF
--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -261,9 +261,11 @@ struct spe_ctl_hdr
 #define SPE_OPERATON_FILTER_ST 0b100
     UINT64 event_filter;
     UINT64 config_flags;
-    UINT32 interval;
 #define SPE_CTL_FLAG_RND (0x1 << 0)     // config_flags: jitter filter flag
 #define SPE_CTL_FLAG_TS  (0x1 << 1)     // config_flags: ts_enable filter flag
+#define SPE_CTL_FLAG_MIN (0x1 << 2)     // config_flags: min_latency=<n> filter flag
+#define SPE_CTL_FLAG_VAL_MASK 0xFFFF    // PMSLATFR_EL1.MINLAT is 16-bit wide
+    UINT32 interval;
 };
 
 //

--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -265,6 +265,7 @@ struct spe_ctl_hdr
 #define SPE_CTL_FLAG_TS  (0x1 << 1)     // config_flags: ts_enable filter flag
 #define SPE_CTL_FLAG_MIN (0x1 << 2)     // config_flags: min_latency=<n> filter flag
 #define SPE_CTL_FLAG_VAL_MASK 0xFFFF    // PMSLATFR_EL1.MINLAT is 16-bit wide
+#define SPE_CTL_FLAG_VAL_12_BIT_MASK 0x0FFF    // PMSLATFR_EL1.MINLAT is 12-bit wide if CountSize == 0b0010
     UINT32 interval;
 };
 

--- a/wperf-driver/spe.c
+++ b/wperf-driver/spe.c
@@ -124,10 +124,11 @@ VOID SPEWorkItemFunc(WDFWORKITEM WorkItem)
                 }
                 _WriteStatusReg(PMSLATFR_EL1, min_latency); // Configure PMSLATFR_EL1.MINLAT
 
-                pmsfcr &= PMSFCR_EL1_FL;    // Enable Filter by latency
+                pmsfcr |= PMSFCR_EL1_FL;    // Enable Filter by latency
                 KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "SPE: min_latency=%u PMSFCR_EL1=0x%llX\n", min_latency, pmsfcr));
             }
 
+            KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "SPE: pmsfcr=0x%llX \n", pmsfcr));
             _WriteStatusReg(PMSFCR_EL1, pmsfcr);
 
             /*

--- a/wperf-driver/spe.h
+++ b/wperf-driver/spe.h
@@ -37,10 +37,17 @@
 #define PMSCR_EL1_E0SPE_E1SPE               0b11
 #define PMBLIMITR_EL1_E                     1ULL
 #define PMBSR_EL1_S                         BIT(17)
-#define PMSFCR_EL1_ST                       BIT(18)
-#define PMSFCR_EL1_LD                       BIT(17)
-#define PMSFCR_EL1_B                        BIT(16)
-#define PMSFCR_EL1_FT                       BIT(1)
+
+#define PMSFCR_EL1_ST                       BIT(18) // Store filter enable
+#define PMSFCR_EL1_LD                       BIT(17) // Load filter enable
+#define PMSFCR_EL1_B                        BIT(16) // Branch filter enable
+#define PMSFCR_EL1_FT                       BIT(1)  // Filter by operation type
+#define PMSFCR_EL1_FL                       BIT(2)  // Filter by latency
+
+#define PMSIDR_EL1_CountSize_MASK           (0x0F << 16)    // CountSize, bits [19:16]
+#define PMSIDR_EL1_CountSize_12Bit          0b0010          // 12-bit saturating counters.
+#define PMSIDR_EL1_CountSize_16Bit          0b0011          // 16-bit saturating counters.
+
 #define PMSIRR_EL1_RND                      BIT(0)
 #define PMBLIMITR_EL1_LIMIT_MASK            (~((UINT64)0xFFF))  // PMBLIMITR.LIMIT, bits [63:12]
 

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -108,6 +108,15 @@ def test_cpython_bench_spe_cli_incorrect_filter(SPE_FILTERS):
     ("b=1,load_filter=10"),
     ("b=0,store_filter=0x2"),
     ("b=1,branch_filter=0xf1da"),
+
+    ("ld=1,min=0x10000"),
+    ("load_filter=1,min=0x10000"),
+    ("ld=1,min=0x10000,store_filter=0"),
+    ("load_filter=1,min=0x10000,store_filter=0"),
+    ("ld=1,min_latency=0x10000"),
+    ("load_filter=1,min_latency=0x10000"),
+    ("ld=1,min_latency=0x10000,store_filter=0"),
+    ("load_filter=1,min_latency=0x10000,store_filter=0"),
 ]
 )
 def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):

--- a/wperf/README.md
+++ b/wperf/README.md
@@ -1767,21 +1767,30 @@ If `FeatureString` for both components (`wperf` and `wperf-driver`) contains `+s
 
 ### arm_spe_0// format
 
-Users can specify SPE filters using the `-e` command line option with `arm_spe_0//`. We've introduced the `arm_spe_0/*/` notation for the `record` command, where `*` represents a comma-separated list of supported filters. Currently, we support filters such as `store_filter=`, `load_filter=`, `branch_filter=` and `ts_enable=`, or their short equivalents like `st=`, `ld=`, `b=` and `ts=`. Use `0` or `1` to disable or enable a given filter. For example:
+Users can specify SPE filters using the `-e` command line option with `arm_spe_0//`. We've introduced the `arm_spe_0/*/` notation for the `record` command, where `*` represents a comma-separated list of supported filters. Currently, we support filters such as:
+- `store_filter=`, `load_filter=`, `branch_filter=`, `min_latency=` and `ts_enable=`,
+- or their short equivalents like `st=`, `ld=`, `b=`, `min=` and `ts=`.
+
+> Use `0` or `1` to disable or enable a given filter.
+
+#### arm_spe_0// format examples
 
 ```
 arm_spe_0/branch_filter=1/
 arm_spe_0/load_filter=1,branch_filter=0/
 arm_spe_0/ld=1,branch_filter=0/
 arm_spe_0/st=0,ld=0,b=1/
+arm_spe_0/st=0,min_latency=1024/
+arm_spe_0/st=0,min_latency=1024,ts_enable=1/
 ```
 
 ### List of supported SPE filters
 
-- `branch_filter=1`- collect branches only.
-- `load_filter=1` - collect loads only.
-- `store_filter=1` - collect stores only.
+- `branch_filter=1`- collect branches only. For filtering purposes, branch operations include exception returns.
+- `load_filter=1` - collect loads only. For filtering purposes, load operations include vector loads and atomic operations.
+- `store_filter=1` - collect stores only. For filtering purposes, store operations include vector stores and all atomic operations.
 - `ts_enable=1` - enable timestamping with value of generic timer.
+- `min_latency=<n>` - collect only samples with `<n>` latency or higher. Latency is the total latency from the point at which sampling started on that instruction, rather than only the execution latency. Samples with a total latency less than `<n>` are not recorded.
 
 #### Filtering sample records
 

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -348,12 +348,28 @@ void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
     ctl.event_filter = 0;
     UINT8 opfilter = 0;
     UINT64 config_flags = 0;
+    /*
+    * `config_flags` stores multiple values:
+    *
+    * 63                    47                8                       0
+    * +---------------------------------------------------------------+
+    * | PMSLATFR_EL1.MINLAT |      ....       |    SPE_CTL_FLAG_*     |
+    * +---------------------------------------------------------------+
+    *
+    */
+
     for (const auto& [key, val] : flags)
     {
-        if ((key == L"load_filter" || key == L"ld") && val)     opfilter |= SPE_OPERATON_FILTER_LD;
-        if ((key == L"store_filter" || key == L"st") && val)    opfilter |= SPE_OPERATON_FILTER_ST;
+        if ((key == L"load_filter"   || key == L"ld") && val)   opfilter |= SPE_OPERATON_FILTER_LD;
+        if ((key == L"store_filter"  || key == L"st") && val)   opfilter |= SPE_OPERATON_FILTER_ST;
         if ((key == L"branch_filter" || key == L"b") && val)    opfilter |= SPE_OPERATON_FILTER_B;
-        if ((key == L"ts_enable" || key == L"ts") && val)       config_flags |= SPE_CTL_FLAG_TS;
+        if ((key == L"ts_enable"     || key == L"ts") && val)   config_flags |= SPE_CTL_FLAG_TS;
+        if ((key == L"min_latency"   || key == L"min") && val)
+        {
+            UINT64 minlat = val & SPE_CTL_FLAG_VAL_MASK;   // PMSLATFR_EL1.MINLAT is 16 - bit value
+            config_flags |= (minlat << 48);
+            config_flags |= SPE_CTL_FLAG_MIN;
+        }
     }
     ctl.operation_filter = opfilter;
     ctl.interval = 1024;

--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -405,14 +405,20 @@ namespace SPEParser
 }
 
 const std::vector<std::wstring> spe_device::m_filter_names = {
-        L"load_filter", L"store_filter", L"branch_filter", L"ts_enable"};
+    L"load_filter",
+    L"store_filter",
+    L"branch_filter",
+    L"ts_enable",
+    L"min_latency"
+};
 
 // Filters also have aliases, this structure helps to translate alias to filter name
 const std::map<std::wstring, std::wstring> spe_device::m_filter_names_aliases = {
-    { L"ld", L"load_filter", },
-    { L"st", L"store_filter", },
-    { L"b" , L"branch_filter" },
-    { L"ts", L"ts_enable" }
+    { L"ld",  L"load_filter" },
+    { L"st",  L"store_filter" },
+    { L"b" ,  L"branch_filter" },
+    { L"ts",  L"ts_enable" },
+    { L"min", L"min_latency" }
 };
 
 // Filters also have aliases, this structure helps to translate alias to filter name
@@ -420,7 +426,8 @@ const std::map<std::wstring, std::wstring> spe_device::m_filter_names_descriptio
     { L"load_filter",   L"Enables collection of load sampled operations, including atomic operations that return a value to a register." },
     { L"store_filter",  L"Enables collection of store sampled operations, including all atomic operations." },
     { L"branch_filter", L"Enables collection of branch sampled operations, including direct and indirect branches and exception returns." },
-    { L"ts_enable",     L"Enables timestamping with value of generic timer." }
+    { L"ts_enable",     L"Enables timestamping with value of generic timer." },
+    { L"min_latency",   L"Collect only samples with this latency or higher." }
 };
 
 spe_device::spe_device() {}

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -75,8 +75,9 @@ public:
 
     static uint64_t max_filter_val(std::wstring fname)
     {
-        if (CaseInsensitiveWStringComparision(fname, L"min_latency"))
-            return 0xFFFF;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
+        if (CaseInsensitiveWStringComparision(fname, L"min_latency") ||
+            CaseInsensitiveWStringComparision(fname, L"min"))
+            return SPE_CTL_FLAG_VAL_MASK;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
         return 1;
     }
 };


### PR DESCRIPTION
## Introduction
This pull request introduces the minimum latency filter functionality to the WindowsPerf tool.
New command line SPE filter `min_latency` takes value between 0-0xFFFF, please note that for some systems this value is 12-bit wide (0x0FFF).

## min_latency / min

`min_latency=<n>` / `min` - collect only samples with this latency or higher* (see sysreg: PMSLATFR).

* Latency is the total latency from the point at which sampling started on that instruction, rather than only the execution latency.

## Changelog
- wperf: Updated README to include documentation for the min_latency filter.
- wperf-scripts: Added maximum tests for tests/wperf_cli_cpython_dep_record_spe_test.
- wperf-driver: Enabled filtering by latency.
- wperf-driver: Added support for min_latency=<n> parameter.
- wperf: Included min_latency in spe_ctl_hdr.config_flags.
- wperf: Added min_latency filter name to the SPE filter list.

# Testing
```
>pytest
====================================================== test session starts ======================================================
platform win32 -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0
configfile: pytest.ini
collected 860 items

wperf_cli_common_test.py ....                                                                                              [  0%]
wperf_cli_config_test.py .....                                                                                             [  1%]
wperf_cli_cpython_bench_test.py .s                                                                                         [  1%]
wperf_cli_cpython_dep_record_spe_test.py ................................................................................. [ 10%]
..                                                                                                                         [ 10%]
wperf_cli_cpython_dep_record_test.py ...........                                                                           [ 12%]
wperf_cli_cpython_dep_sample_test.py .                                                                                     [ 12%]
wperf_cli_dmc_test.py .                                                                                                    [ 12%]
wperf_cli_dmc_value_test.py .                                                                                              [ 12%]
wperf_cli_extra_events_test.py ....                                                                                        [ 13%]
wperf_cli_hammer_core_test.py ..................                                                                           [ 15%]
wperf_cli_help_test.py ..                                                                                                  [ 15%]
wperf_cli_info_str_test.py .                                                                                               [ 15%]
wperf_cli_json_validator_test.py ...............                                                                           [ 17%]
wperf_cli_list_test.py ......                                                                                              [ 17%]
wperf_cli_lock_test.py .....                                                                                               [ 18%]
wperf_cli_man_test.py .................................................................                                    [ 26%]
wperf_cli_man_ts_test.py ................................................................................................. [ 37%]
.............................................................                                                              [ 44%]
wperf_cli_metrics_test.py ........                                                                                         [ 45%]
wperf_cli_metrics_ts_test.py ..........................................................................                    [ 53%]
wperf_cli_padding_test.py ..............                                                                                   [ 55%]
wperf_cli_prettytable_test.py .....                                                                                        [ 56%]
wperf_cli_record_test.py ................s                                                                                 [ 58%]
wperf_cli_sample_test.py ..........                                                                                        [ 59%]
wperf_cli_stat_test.py ......................................................................                              [ 67%]
wperf_cli_stat_value_test.py ............................................................................................. [ 78%]
.......................................................................................                                    [ 88%]
wperf_cli_test_test.py ...........                                                                                         [ 89%]
wperf_cli_timeline_test.py ...............................................                                                 [ 95%]
wperf_cli_ustress_bench_test.py ......                                                                                     [ 95%]
wperf_cli_ustress_dep_record_test.py ..                                                                                    [ 96%]
wperf_cli_ustress_dep_wperf_lib_timeline_test.py .                                                                         [ 96%]
wperf_cli_ustress_dep_wperf_test.py ............                                                                           [ 97%]
wperf_cli_ustress_timeline_test.py ..................                                                                      [ 99%]
wperf_cli_xperf_test.py s                                                                                                  [ 99%]
wperf_lib_app_test.py .                                                                                                    [ 99%]
wperf_lib_c_compat_test.py .                                                                                               [100%]
================================================ WindowsPerf Test Configuration =================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 05/11/2024, 05:45:29
wperf: 3.8.0.342addb4-dirty+etw-app+spe
wperf-driver: 3.8.0.342addb4-dirty+trace+spe

==================================================== short test summary info ====================================================
SKIPPED [1] wperf_cli_cpython_bench_test.py:80: skipping CPython rebuild procedure (already built), cleanup CPython build with 'cpython\PCbuild\clean.bat'
SKIPPED [1] wperf_cli_record_test.py:158: this test is applicable only if `gpc_num` < `total_gpc_num`, now: gpc_num=6 and total_gpc_num=6
SKIPPED [1] wperf_cli_xperf_test.py:64: skipping XPERF test bench, enable it with `--enable-bench-xperf` command line options
========================================== 857 passed, 3 skipped in 2109.13s (0:35:09) ==========================================
```