### PR TITLE
Add SPE filter name getter from alias or name

### DIFF
--- a/wperf-test/wperf-test-spe_device.cpp
+++ b/wperf-test/wperf-test-spe_device.cpp
@@ -86,7 +86,7 @@ namespace wperftest
 
 		TEST_METHOD(test_spe_device_filter_name_is_alias)
 		{
-			Assert::IsTrue(spe_device::is_filter_name_alias (L"ld"));
+			Assert::IsTrue(spe_device::is_filter_name_alias(L"ld"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"st"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"b"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"ts"));
@@ -100,10 +100,14 @@ namespace wperftest
 			Assert::AreEqual(spe_device::get_filter_name(L"ts").c_str(), L"ts_enable");
 			Assert::AreEqual(spe_device::get_filter_name(L"min").c_str(), L"min_latency");
 
-			uint64_t val = SPE_CTL_FLAG_VAL_MASK;
+		}
 
-			Assert::AreEqual(spe_device::max_filter_val(L"min"), val);
-			Assert::AreEqual(spe_device::max_filter_val(L"min_latency"), val);
+		TEST_METHOD(test_max_filter_val)
+		{
+			Assert::AreEqual(spe_device::max_filter_val(L"min"), (uint64_t)SPE_CTL_FLAG_VAL_MASK);
+			Assert::AreEqual(spe_device::max_filter_val(L"min_latency"), (uint64_t)SPE_CTL_FLAG_VAL_MASK);
+			Assert::AreEqual(spe_device::max_filter_val(L"ld"), (uint64_t)1);
+			Assert::AreEqual(spe_device::max_filter_val(L"ts"), (uint64_t)1);
 		}
 	};
 }

--- a/wperf-test/wperf-test-spe_device.cpp
+++ b/wperf-test/wperf-test-spe_device.cpp
@@ -99,6 +99,11 @@ namespace wperftest
 			Assert::AreEqual(spe_device::get_filter_name(L"b").c_str(), L"branch_filter");
 			Assert::AreEqual(spe_device::get_filter_name(L"ts").c_str(), L"ts_enable");
 			Assert::AreEqual(spe_device::get_filter_name(L"min").c_str(), L"min_latency");
+
+			uint64_t val = SPE_CTL_FLAG_VAL_MASK;
+
+			Assert::AreEqual(spe_device::max_filter_val(L"min"), val);
+			Assert::AreEqual(spe_device::max_filter_val(L"min_latency"), val);
 		}
 	};
 }

--- a/wperf-test/wperf-test-spe_device.cpp
+++ b/wperf-test/wperf-test-spe_device.cpp
@@ -94,11 +94,11 @@ namespace wperftest
 
 		TEST_METHOD(test_spe_device_get_filter_name)
 		{
-			Assert::AreEqual(spe_device::get_filter_name(L"ld").c_str(), L"load_filter");
-			Assert::AreEqual(spe_device::get_filter_name(L"st").c_str(), L"store_filter");
-			Assert::AreEqual(spe_device::get_filter_name(L"b").c_str(), L"branch_filter");
-			Assert::AreEqual(spe_device::get_filter_name(L"ts").c_str(), L"ts_enable");
-			Assert::AreEqual(spe_device::get_filter_name(L"min").c_str(), L"min_latency");
+			Assert::AreEqual(spe_device::get_filter_name(L"ld"), std::wstring(L"load_filter"));
+			Assert::AreEqual(spe_device::get_filter_name(L"st"), std::wstring(L"store_filter"));
+			Assert::AreEqual(spe_device::get_filter_name(L"b"), std::wstring(L"branch_filter"));
+			Assert::AreEqual(spe_device::get_filter_name(L"ts"), std::wstring(L"ts_enable"));
+			Assert::AreEqual(spe_device::get_filter_name(L"min"), std::wstring(L"min_latency"));
 
 		}
 

--- a/wperf-test/wperf-test-spe_device.cpp
+++ b/wperf-test/wperf-test-spe_device.cpp
@@ -91,5 +91,14 @@ namespace wperftest
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"b"));
 			Assert::IsTrue(spe_device::is_filter_name_alias(L"ts"));
 		}
+
+		TEST_METHOD(test_spe_device_get_filter_name)
+		{
+			Assert::AreEqual(spe_device::get_filter_name(L"ld").c_str(), L"load_filter");
+			Assert::AreEqual(spe_device::get_filter_name(L"st").c_str(), L"store_filter");
+			Assert::AreEqual(spe_device::get_filter_name(L"b").c_str(), L"branch_filter");
+			Assert::AreEqual(spe_device::get_filter_name(L"ts").c_str(), L"ts_enable");
+			Assert::AreEqual(spe_device::get_filter_name(L"min").c_str(), L"min_latency");
+		}
 	};
 }

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -360,11 +360,11 @@ void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
 
     for (const auto& [key, val] : flags)
     {
-        if ((key == L"load_filter"   || key == L"ld") && val)   opfilter |= SPE_OPERATON_FILTER_LD;
-        if ((key == L"store_filter"  || key == L"st") && val)   opfilter |= SPE_OPERATON_FILTER_ST;
-        if ((key == L"branch_filter" || key == L"b") && val)    opfilter |= SPE_OPERATON_FILTER_B;
-        if ((key == L"ts_enable"     || key == L"ts") && val)   config_flags |= SPE_CTL_FLAG_TS;
-        if ((key == L"min_latency"   || key == L"min") && val)
+        if (spe_device::get_filter_name(key) == L"load_filter" && val)   opfilter |= SPE_OPERATON_FILTER_LD;
+        if (spe_device::get_filter_name(key) == L"store_filter" && val)   opfilter |= SPE_OPERATON_FILTER_ST;
+        if (spe_device::get_filter_name(key) == L"branch_filter" && val)    opfilter |= SPE_OPERATON_FILTER_B;
+        if (spe_device::get_filter_name(key) == L"ts_enable" && val)   config_flags |= SPE_CTL_FLAG_TS;
+        if (spe_device::get_filter_name(key) == L"min_latency" && val)
         {
             UINT64 minlat = val & SPE_CTL_FLAG_VAL_MASK;   // PMSLATFR_EL1.MINLAT is 16 - bit value
             config_flags |= (minlat << 48);

--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -489,6 +489,12 @@ bool spe_device::is_spe_supported(UINT64 id_aa64dfr0_el1_value)
 #endif
 }
 
+/// <summary>
+/// Retrieves the filter name for the given filter name or alias. If the filter name is an alias,
+/// the corresponding filter name is returned; otherwise, the original filter name is returned.
+/// </summary>
+/// <param name="fname">The filter name or alias for which the filter name is to be retrieved.</param>
+/// <returns>The filter name if the full filter name.</returns>
 std::wstring spe_device::get_filter_name(std::wstring fname)
 {
     if (is_filter_name_alias(fname))

--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -488,3 +488,10 @@ bool spe_device::is_spe_supported(UINT64 id_aa64dfr0_el1_value)
     return false;
 #endif
 }
+
+std::wstring spe_device::get_filter_name(std::wstring fname)
+{
+    if (is_filter_name_alias(fname))
+        return m_filter_names_aliases.at(fname);
+    return fname;
+}

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -75,8 +75,7 @@ public:
 
     static uint64_t max_filter_val(std::wstring fname)
     {
-        if (CaseInsensitiveWStringComparision(fname, L"min_latency") ||
-            CaseInsensitiveWStringComparision(fname, L"min"))
+        if (get_filter_name(fname) == L"min_latency")
             return SPE_CTL_FLAG_VAL_MASK;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
         return 1;
     }

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -64,7 +64,7 @@ public:
     static void get_samples(const std::vector<UINT8>& spe_buffer, std::vector<FrameChain>& raw_samples, std::map<UINT64, std::wstring>& spe_events);
 
     static bool is_filter_name(std::wstring fname) {
-        if (m_filter_names_aliases.count(fname))
+        if (is_filter_name_alias(fname))
             fname = m_filter_names_aliases.at(fname);
         return std::find(m_filter_names.begin(), m_filter_names.end(), fname) != m_filter_names.end();
     }
@@ -80,4 +80,6 @@ public:
             return SPE_CTL_FLAG_VAL_MASK;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
         return 1;
     }
+
+    static std::wstring get_filter_name(std::wstring fname);
 };


### PR DESCRIPTION
## Description

This pull request introduces a new method to streamline the handling of filter names and refactors existing code to utilize this new method. The most important changes include the addition of the `get_filter_name` method in the `spe_device` class, updates to unit tests, and refactoring of code to use the new method.

### New Method Addition:

* Added `get_filter_name` method to the `spe_device` class to map filter name aliases to their corresponding full names. (`wperf/spe_device.cpp`, `wperf/spe_device.h`) [[1]](diffhunk://#diff-a581032e5433506e760970f831be3e72ac1d2b07b7de200ccbd5b864c11fdd08R491-R497) [[2]](diffhunk://#diff-54d7d83a4a88365e079290511e123ee13f784d1787821a44e0b7468b673977a2L78-R83)


### Refactoring:

* Updated `spe_start` method in `pmu_device` to use the new `get_filter_name` method for filter name resolution. (`wperf/pmu_device.cpp`)
* Refactored `is_filter_name` method to use the `is_filter_name_alias` method for alias checking. (`wperf/spe_device.h`)
* Modified `max_filter_val` method to use the `get_filter_name` method for consistent filter name resolution. (`wperf/spe_device.h`)

## Related Issue
Fixes #63 .

## Commits
<!-- Commits will be listed automatically when the PR is created -->
${{ github.event.pull_request.commits }}

## How Has This Been Tested?
* Added `test_spe_device_get_filter_name` method to test the new `get_filter_name` method (`wperf-test/wperf-test-spe_device.cpp`).
![image](https://github.com/user-attachments/assets/0fb706a7-c2ca-4c54-a412-35c80e208aa7)
