### PR TITLE
Add symbol name for `pcs` list of PCs in sampling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ make_arch=ARM64
 
 # By default we build with Debug configuration. Define config variable to change default
 # value.
-make_config=Debug
+make_config=Debug+SPE
 
 ifdef arch
 	make_arch=$(arch)

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ make_arch=ARM64
 
 # By default we build with Debug configuration. Define config variable to change default
 # value.
-make_config=Debug+SPE
+make_config=Debug
 
 ifdef arch
 	make_arch=$(arch)

--- a/wperf-scripts/tests/schemas/wperf.sample.schema
+++ b/wperf-scripts/tests/schemas/wperf.sample.schema
@@ -67,7 +67,7 @@
                                                             }
                                                           }
                                                         }
-                                                      } 
+                                                      }
                                                     }
                                                 }
                                             }
@@ -77,14 +77,15 @@
 
                                 },
                             },
-                            "pcs": {  
-                            "type": "array",                      
+                            "pcs": {
+                            "type": "array",
                             "items": {
                                 "type": "object",
-                                "required": [ "address", "count" ],
+                                "required": [ "address", "count", "in_symbol" ],
                                 "properties": {
                                     "address": { "type" : "integer" },
-                                    "count": { "type": "integer" }
+                                    "count": { "type": "integer" },
+                                    "in_symbol": { "type": "string" }
                                 }
                             },
                             },
@@ -112,7 +113,7 @@
                         }
                     }
                 },
-                "modules_info": { 
+                "modules_info": {
                 	"type" : "array",
                     "items": {
                       "type": "object",

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -59,7 +59,7 @@ if not wperf_event_is_available("arm_spe_0//"):
 
 ### Test cases
 
-@pytest.mark.parametrize("SPE_FILTERS",
+@pytest.mark.parametrize("spe_filters",
 [
     ("x"),
     ("_"),
@@ -82,22 +82,22 @@ if not wperf_event_is_available("arm_spe_0//"):
     ("load_filter=0,branch_filter"),      # Should be e.g. `branch_filter=0`
 ]
 )
-def test_cpython_bench_spe_cli_incorrect_filter(SPE_FILTERS):
+def test_cpython_bench_spe_cli_incorrect_filter(spe_filters):
     """ Test `wperf record` with SPE CLI not OK filters, we expect:
 
-    "incorrect SPE filter: '<SPE_FILTERS>' in <SPE_FILTERS>"
+    "incorrect SPE filter: '<spe_filters>' in <spe_filters>"
 
     """
     #
     # Run for CPython payload but we should fail when we hit CLI parser errors
     #
-    cmd = f"wperf record -e arm_spe_0/{SPE_FILTERS}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
+    cmd = f"wperf record -e arm_spe_0/{spe_filters}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
     _, stderr = run_command(cmd)
 
     assert b"unexpected arg" not in stderr
     assert b"incorrect SPE filter:" in stderr
 
-@pytest.mark.parametrize("SPE_FILTERS",
+@pytest.mark.parametrize("spe_filters",
 [
     ("b=2"),
     ("ld=3"),
@@ -119,7 +119,7 @@ def test_cpython_bench_spe_cli_incorrect_filter(SPE_FILTERS):
     ("load_filter=1,min_latency=0x10000,store_filter=0"),
 ]
 )
-def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):
+def test_cpython_bench_spe_cli_filter_value_out_of_range(spe_filters):
     """ Test `wperf record` with SPE CLI filter value
 
     "SPE filter 'ts_enable' value out of range, use: 0-1"
@@ -128,7 +128,7 @@ def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):
     #
     # Run for CPython payload but we should fail when we hit CLI parser errors
     #
-    cmd = f"wperf record -e arm_spe_0/{SPE_FILTERS}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
+    cmd = f"wperf record -e arm_spe_0/{spe_filters}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
     _, stderr = run_command(cmd)
 
     assert b"unexpected arg" not in stderr
@@ -143,23 +143,23 @@ def test_cpython_bench_spe_cli_filter_value_out_of_range(SPE_FILTERS):
     ("load_filter=0,=1"),
 ]
 )
-def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
+def test_cpython_bench_spe_cli_incorrect_filter_name(spe_filters):
     """ Test `wperf record` with SPE CLI not OK filters, we expect:
 
-    "incorrect SPE filter name: '<SPE_FILTERS>' in <SPE_FILTERS>"
+    "incorrect SPE filter name: '<spe_filters>' in <spe_filters>"
 
     This error is for "empty" filter name.
     """
     #
     # Run for CPython payload but we should fail when we hit CLI parser errors
     #
-    cmd = f"wperf record -e arm_spe_0/{SPE_FILTERS}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
+    cmd = f"wperf record -e arm_spe_0/{spe_filters}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
     _, stderr = run_command(cmd)
 
     assert b"unexpected arg" not in stderr
     assert b"incorrect SPE filter name:" in stderr
 
-@pytest.mark.parametrize("SPE_FILTERS",
+@pytest.mark.parametrize("spe_filters",
 [
     ("load_filter="),
     ("store_filter="),
@@ -199,15 +199,15 @@ def test_cpython_bench_spe_cli_incorrect_filter_name(SPE_FILTERS):
     ("load_filter=0,b=-1"),
 ]
 )
-def test_cpython_bench_spe_cli_incorrect_filter_value(SPE_FILTERS):
+def test_cpython_bench_spe_cli_incorrect_filter_value(spe_filters):
     """ Test `wperf record` with SPE CLI not OK filters, we expect:
 
-    "incorrect SPE filter value: '<SPE_FILTERS>' in <SPE_FILTERS>"
+    "incorrect SPE filter value: '<spe_filters>' in <spe_filters>"
     """
     #
     # Run for CPython payload but we should fail when we hit CLI parser errors
     #
-    cmd = f"wperf record -e arm_spe_0/{SPE_FILTERS}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
+    cmd = f"wperf record -e arm_spe_0/{spe_filters}/ -c 4 --timeout 3 --json -- python_d.exe -c 10**10**100"
     _, stderr = run_command(cmd)
 
     assert b"unexpected arg" not in stderr
@@ -349,14 +349,14 @@ def test_cpython_bench_spe_json_stdout_schema(request, tmp_path, verbose, event,
     except Exception as err:
         assert False, f"Unexpected {err=}, {type(err)=}, cmd='{cmd}'"
 
-@pytest.mark.parametrize("EVENT,SPE_FILTERS,PYTHON_ARG",
+@pytest.mark.parametrize("spe_filters,python_arg",
 [
-    ("arm_spe_0", "",                   "10**10**100"),
-    ("arm_spe_0", "load_filter=1",      "10**10**100"),
-    ("arm_spe_0", "load_filter=1,st=1", "10**10**100"),
+    ("",                   "10**10**100"),
+    ("load_filter=1",      "10**10**100"),
+    ("load_filter=1,st=1", "10**10**100"),
 ]
 )
-def test_cpython_bench_spe_consistency(request, tmp_path, EVENT,SPE_FILTERS,PYTHON_ARG):
+def test_cpython_bench_spe_consistency(request, tmp_path, spe_filters, python_arg):
     """ Test SPE JSON output against stdout scheme """
     ## Execute benchmark
     pyhton_d_exe_path = os.path.join(CPYTHON_EXE_DIR, "python_d.exe")
@@ -364,7 +364,7 @@ def test_cpython_bench_spe_consistency(request, tmp_path, EVENT,SPE_FILTERS,PYTH
     if not check_if_file_exists(pyhton_d_exe_path):
         pytest.skip(f"Can't locate CPython native executable in {pyhton_d_exe_path}")
 
-    cmd = f"wperf record -e {EVENT}/{SPE_FILTERS}/ -c 2 --timeout 5 --json -- {pyhton_d_exe_path} -c {PYTHON_ARG}"
+    cmd = f"wperf record -e arm_spe_0/{spe_filters}/ -c 2 --timeout 5 --json -- {pyhton_d_exe_path} -c {python_arg}"
     stdout, _ = run_command(cmd.split())
 
     json_output = json.loads(stdout)

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -317,13 +317,19 @@ def test_cpython_bench_spe_json_schema(request, tmp_path, verbose, event, spe_fi
     except Exception as err:
         assert False, f"Unexpected {err=}, {type(err)=}, cmd='{cmd}'"
 
-@pytest.mark.parametrize("EVENT,SPE_FILTERS,PYTHON_ARG",
+@pytest.mark.parametrize("verbose",
+[
+    ("-v"),
+    (""),
+]
+)
+@pytest.mark.parametrize("event,spe_filters,python_arg",
 [
     ("arm_spe_0", "",              "10**10**100"),
     ("arm_spe_0", "load_filter=1", "10**10**100"),
 ]
 )
-def test_cpython_bench_spe_json_stdout_schema(request, tmp_path, EVENT,SPE_FILTERS,PYTHON_ARG):
+def test_cpython_bench_spe_json_stdout_schema(request, tmp_path, verbose, event, spe_filters, python_arg):
     """ Test SPE JSON output against stdout scheme """
     ## Execute benchmark
     pyhton_d_exe_path = os.path.join(CPYTHON_EXE_DIR, "python_d.exe")
@@ -333,7 +339,7 @@ def test_cpython_bench_spe_json_stdout_schema(request, tmp_path, EVENT,SPE_FILTE
 
     test_path = os.path.dirname(request.path)
 
-    cmd = f"wperf record -e {EVENT}/{SPE_FILTERS}/ -c 2 --timeout 5 --json -- {pyhton_d_exe_path} -c {PYTHON_ARG}"
+    cmd = f"wperf record -e {event}/{spe_filters}/ -c 3 {verbose} --timeout 5 --json -- {pyhton_d_exe_path} -c {python_arg}"
     stdout, _ = run_command(cmd.split())
 
     json_output = json.loads(stdout)
@@ -341,7 +347,7 @@ def test_cpython_bench_spe_json_stdout_schema(request, tmp_path, EVENT,SPE_FILTE
     try:
         validate(instance=json_output, schema=get_schema("spe", test_path))
     except Exception as err:
-        assert False, f"Unexpected {err=}, {type(err)=}"
+        assert False, f"Unexpected {err=}, {type(err)=}, cmd='{cmd}'"
 
 @pytest.mark.parametrize("EVENT,SPE_FILTERS,PYTHON_ARG",
 [

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -282,13 +282,19 @@ def test_cpython_bench_spe_hotspot(EVENT,SPE_FILTERS,HOT_SYMBOL,HOT_MINIMUM,PYTH
     #
     assert median(overheads) >= HOT_MINIMUM, f"expected {HOT_MINIMUM}% SPE sampling hotspot in {HOT_SYMBOL}, overheads={overheads}, cmd={cmd}"
 
-@pytest.mark.parametrize("EVENT,SPE_FILTERS,PYTHON_ARG",
+@pytest.mark.parametrize("verbose",
+[
+    ("-v"),
+    (""),
+]
+)
+@pytest.mark.parametrize("event,spe_filters,python_arg",
 [
     ("arm_spe_0", "",              "10**10**100"),
     ("arm_spe_0", "load_filter=1", "10**10**100"),
 ]
 )
-def test_cpython_bench_spe_json_schema(request, tmp_path, EVENT,SPE_FILTERS,PYTHON_ARG):
+def test_cpython_bench_spe_json_schema(request, tmp_path, verbose, event, spe_filters, python_arg):
     """ Test SPE JSON output against scheme """
     ## Execute benchmark
     pyhton_d_exe_path = os.path.join(CPYTHON_EXE_DIR, "python_d.exe")
@@ -299,7 +305,7 @@ def test_cpython_bench_spe_json_schema(request, tmp_path, EVENT,SPE_FILTERS,PYTH
     test_path = os.path.dirname(request.path)
     file_path = tmp_path / 'test.json'
 
-    cmd = f"wperf record -e {EVENT}/{SPE_FILTERS}/ -c 2 --timeout 5 --output {str(file_path)} -- {pyhton_d_exe_path} -c {PYTHON_ARG}"
+    cmd = f"wperf record -e {event}/{spe_filters}/ -c 2 {verbose} --timeout 5 --output {str(file_path)} -- {pyhton_d_exe_path} -c {python_arg}"
     _, _ = run_command(cmd.split())
 
     json_output = {}
@@ -309,7 +315,7 @@ def test_cpython_bench_spe_json_schema(request, tmp_path, EVENT,SPE_FILTERS,PYTH
             json_output = json.loads(json_file.read())
         validate(instance=json_output, schema=get_schema("spe", test_path))
     except Exception as err:
-        assert False, f"Unexpected {err=}, {type(err)=}"
+        assert False, f"Unexpected {err=}, {type(err)=}, cmd='{cmd}'"
 
 @pytest.mark.parametrize("EVENT,SPE_FILTERS,PYTHON_ARG",
 [

--- a/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
+++ b/wperf-scripts/tests/wperf_cli_cpython_dep_record_spe_test.py
@@ -134,7 +134,7 @@ def test_cpython_bench_spe_cli_filter_value_out_of_range(spe_filters):
     assert b"unexpected arg" not in stderr
     assert b"value out of range, use:" in stderr
 
-@pytest.mark.parametrize("SPE_FILTERS",
+@pytest.mark.parametrize("spe_filters",
 [
     ("=0"),
     ("=1"),

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -1283,8 +1283,8 @@ wmain(
 
             TableOutput<SamplingPCOutputTraits<GlobalCharType>, GlobalCharType> pcs_table(m_outputType);
             pcs_table.PresetHeaders();
-            pcs_table.Insert(col_pcs, col_pcs_count);
-            m_globalSamplingJSON.m_map[table.m_event] = std::make_tuple(table, annotateTables,pcs_table);
+            pcs_table.Insert(col_pcs, col_pcs_count, col_pcs_in_symbol);
+            m_globalSamplingJSON.m_map[table.m_event] = std::make_tuple(table, annotateTables, pcs_table);
             m_globalSamplingJSON.m_sample_display_row = request.sample_display_row;
 
             if (m_outputType == TableType::JSON || m_outputType == TableType::ALL)

--- a/wperf/main.cpp
+++ b/wperf/main.cpp
@@ -1022,6 +1022,7 @@ wmain(
                 std::variant<TableOutput<SamplingAnnotateOutputTraitsL<false>, GlobalCharType>,
                              TableOutput<SamplingAnnotateOutputTraitsL<true>, GlobalCharType>>>> annotateTables;
             std::vector<uint64_t> col_pcs, col_pcs_count;
+            std::vector<std::wstring> col_pcs_in_symbol;
             for (auto &a : resolved_samples)
             {
                 if (a.event_src != prev_evt_src)
@@ -1042,7 +1043,7 @@ wmain(
                             table.m_event = GlobalStringType(spe_event_map[prev_evt_src]);
                         TableOutput<SamplingPCOutputTraits<GlobalCharType>, GlobalCharType> pcs_table(m_outputType);
                         pcs_table.PresetHeaders();
-                        pcs_table.Insert(col_pcs, col_pcs_count);
+                        pcs_table.Insert(col_pcs, col_pcs_count, col_pcs_in_symbol);
                         m_globalSamplingJSON.m_map[table.m_event] = std::make_tuple(table, annotateTables, pcs_table);
                         col_overhead.clear();
                         col_count.clear();
@@ -1050,6 +1051,7 @@ wmain(
                         annotateTables.clear();
                         col_pcs.clear();
                         col_pcs_count.clear();
+                        col_pcs_in_symbol.clear();
                     }
                     prev_evt_src = a.event_src;
 
@@ -1106,6 +1108,7 @@ wmain(
                         m_out.GetOutputStream() << L"pc:\t" << IntToHexWideString(a.pc[i].first, 20) << L"\t" << IntToDecWideString(a.pc[i].second, 8) << std::endl;
                         col_pcs.push_back(a.pc[i].first);
                         col_pcs_count.push_back(a.pc[i].second);
+                        col_pcs_in_symbol.push_back(a.desc.name);
                     }
                 }
 

--- a/wperf/output.h
+++ b/wperf/output.h
@@ -290,10 +290,11 @@ template <typename CharType>
 struct SamplingPCOutputTraits : public TableOutputTraits<CharType>
 {
     typedef typename std::conditional_t<std::is_same_v<CharType, char>, std::string, std::wstring> StringType;
-    inline const static std::tuple<uint64_t, uint64_t> columns;
-    inline const static std::tuple<CharType*, CharType*> headers =
+    inline const static std::tuple<uint64_t, uint64_t, StringType> columns;
+    inline const static std::tuple<CharType*, CharType*, CharType*> headers =
         std::make_tuple(LITERALCONSTANTS_GET("address"),
-            LITERALCONSTANTS_GET("count"));
+            LITERALCONSTANTS_GET("count"),
+            LITERALCONSTANTS_GET("in_symbol"));
     inline const static int size = std::tuple_size_v<decltype(headers)>;
     inline const static CharType* key = LITERALCONSTANTS_GET("pcs");
 };


### PR DESCRIPTION
## Description

Added new `in_symbol` for `pcs`. We want to be able to simply resolve PC -> symbol name. This will allow users who have PC from `spe.data` to resolve symbols with our output JSON.

> Note: use `-v` to add optional in verbose mode `pcs` data.

Generated with:
```posh
wperf record -e arm_spe_0/ld=1/ -c 7 -v --json --timeout 10 -- cpython\PCbuild\arm64\python_d.exe -c 18**10**100
```

```json
"pcs": [
    {
        "address": 140705713767356,
        "count": 1,
        "in_symbol": "x_mul:python312_d.dll"
    },
    {
        "address": 140705713767336,
        "count": 1,
        "in_symbol": "x_mul:python312_d.dll"
    },
    {
        "address": 140705713767368,
        "count": 1,
        "in_symbol": "x_mul:python312_d.dll"
    },
    {
        "address": 140705713760840,
        "count": 1,
        "in_symbol": "v_isub:python312_d.dll"
    },
    {
        "address": 140705713760776,
        "count": 1,
        "in_symbol": "v_isub:python312_d.dll"
    }
],

```

## Example JSON output

You can find example JSON file with new format here: [in_symbol.json](https://github.com/user-attachments/files/17659729/in_symbol.json).

## Testing

```
>pytest -k _schema -v
=============================================================================================================== test session starts ===============================================================================================================
platform win32 -- Python 3.12.3, pytest-8.2.0, pluggy-1.5.0 -- C:\Users\$USER\AppData\Local\Programs\Python\Python312-arm64\python.exe
cachedir: .pytest_cache
configfile: pytest.ini
collected 860 items / 842 deselected / 18 selected

wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_schema[arm_spe_0--10**10**100] PASSED                                                                                                                                  [  5%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_schema[arm_spe_0-load_filter=1-10**10**100] PASSED                                                                                                                     [ 11%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_stdout_schema[arm_spe_0--10**10**100] PASSED                                                                                                                           [ 16%]
wperf_cli_cpython_dep_record_spe_test.py::test_cpython_bench_spe_json_stdout_schema[arm_spe_0-load_filter=1-10**10**100] PASSED                                                                                                              [ 22%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[version] PASSED                                                                                                                                                                     [ 27%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[list] PASSED                                                                                                                                                                        [ 33%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[test] PASSED                                                                                                                                                                        [ 38%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[stat] PASSED                                                                                                                                                                        [ 44%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[detect] PASSED                                                                                                                                                                      [ 50%]
wperf_cli_json_validator_test.py::test_wperf_json_schema[man] PASSED                                                                                                                                                                         [ 55%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[version] PASSED                                                                                                                                                              [ 61%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[list] PASSED                                                                                                                                                                 [ 66%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[test] PASSED                                                                                                                                                                 [ 72%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[stat] PASSED                                                                                                                                                                 [ 77%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[detect] PASSED                                                                                                                                                               [ 83%]
wperf_cli_json_validator_test.py::test_wperf_json_stdout_schema[man] PASSED                                                                                                                                                                  [ 88%]
wperf_cli_json_validator_test.py::test_wperf_timeline_json_schema PASSED                                                                                                                                                                     [ 94%]
wperf_cli_json_validator_test.py::test_wperf_timeline_json_stdout_schema PASSED                                                                                                                                                              [100%]
========================================================================================================= WindowsPerf Test Configuration ==========================================================================================================
OS: Windows-11-10.0.26100-SP0, ARM64
CPU: 80 x ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R)
Python: 3.12.3 (tags/v3.12.3:f6650f9, Apr  9 2024, 14:18:48) [MSC v.1938 64 bit (ARM64)]
Time: 06/11/2024, 05:47:35
wperf: 3.8.0.895ba758-dirty+etw-app+spe
wperf-driver: 3.8.0.85fe3b71-dirty+trace+spe
```