### PR TITLE
[wperf-scripts] Add flake8 and mypy config to wperf-scripts/tests

### DIFF
--- a/wperf-scripts/setup.cfg
+++ b/wperf-scripts/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501, W503
+exclude = .venv

--- a/wperf-scripts/setup.cfg
+++ b/wperf-scripts/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-ignore = E501, W503
-exclude = .venv

--- a/wperf-scripts/tests/.flake8
+++ b/wperf-scripts/tests/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501, W503
+exclude = .venv, telemetry-solution, cpython

--- a/wperf-scripts/tests/Makefile
+++ b/wperf-scripts/tests/Makefile
@@ -1,0 +1,12 @@
+# Define the directories to check
+SRC_DIRS := .
+
+.PHONY: all mypy flake8
+
+all: mypy flake8
+
+mypy:
+	-python -m mypy $(SRC_DIRS)
+
+flake8:
+	-python -m flake8 $(SRC_DIRS)

--- a/wperf-scripts/tests/mypy.ini
+++ b/wperf-scripts/tests/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+# Specify the directories to ignore
+exclude = telemetry-solution|cpython
+ignore_missing_imports = True


### PR DESCRIPTION
## Description

- Add `.flake8`, and `mypy.ini` files to configure these tools. Also add simple Makefile to run these two commands from `/wperf-scripts/tests` directory.
- Ignore `telemetry-solution` and `cpython` sub-modules.

```
>make flake8
>make mypy
>make all
```

## Example usage

```
/wperf-scripts/tests$ make flake8
python -m flake8 .
.\common.py:39:1: E266 too many leading '#' for block comment
.\common.py:59:1: E302 expected 2 blank lines, found 1
.\common.py:67:1: E302 expected 2 blank lines, found 1
.\common.py:73:1: E302 expected 2 blank lines, found 1
...
```