### PR TITLE
[Draft] [SPE] Add jutter to SPE functionality

### DIFF
--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -267,7 +267,7 @@ struct spe_ctl_hdr
 #define SPE_CTL_FLAG_VAL_MASK 0xFFFF    // PMSLATFR_EL1.MINLAT is 16-bit wide
 #define SPE_CTL_FLAG_VAL_12_BIT_MASK 0x0FFF    // PMSLATFR_EL1.MINLAT is 12-bit wide if CountSize == 0b0010
     UINT32 interval;
-#define SPE_CTL_INTERVAL_VAL_MASK 0x0FFF    // INTERVAL, bits [31:8] is interval counter reload value
+#define SPE_CTL_INTERVAL_VAL_MASK 0x0FFFFF    // INTERVAL, bits [31:8] is interval counter reload value
 };
 
 //

--- a/wperf-common/iorequest.h
+++ b/wperf-common/iorequest.h
@@ -267,6 +267,7 @@ struct spe_ctl_hdr
 #define SPE_CTL_FLAG_VAL_MASK 0xFFFF    // PMSLATFR_EL1.MINLAT is 16-bit wide
 #define SPE_CTL_FLAG_VAL_12_BIT_MASK 0x0FFF    // PMSLATFR_EL1.MINLAT is 12-bit wide if CountSize == 0b0010
     UINT32 interval;
+#define SPE_CTL_INTERVAL_VAL_MASK 0x0FFF    // INTERVAL, bits [31:8] is interval counter reload value
 };
 
 //

--- a/wperf-driver/spe.h
+++ b/wperf-driver/spe.h
@@ -47,8 +47,9 @@
 #define PMSIDR_EL1_CountSize_MASK           (0x0F << 16)    // CountSize, bits [19:16]
 #define PMSIDR_EL1_CountSize_12Bit          0b0010          // 12-bit saturating counters.
 #define PMSIDR_EL1_CountSize_16Bit          0b0011          // 16-bit saturating counters.
+#define PMSIDR_EL1_Interval_MASK            (0x0F << 8)     // Recommended minimum sampling interval.
 
-#define PMSIRR_EL1_RND                      BIT(0)
+#define PMSIRR_EL1_RND                      BIT(0)              // Add (pseudo-)random jitter to sampling interval.
 #define PMBLIMITR_EL1_LIMIT_MASK            (~((UINT64)0xFFF))  // PMBLIMITR.LIMIT, bits [63:12]
 
 #define SPE_MEMORY_BUFFER_SIZE              (PAGE_SIZE*128)     // PAGE_SIZE is defined in WDM.h
@@ -112,3 +113,4 @@ void spe_destroy();
 
 NTSTATUS spe_setup(ULONG numCores);
 void spe_destroy();
+UINT32 spe_recommended_min_sampling_interval(UINT64 pmsidr_el1_value);

--- a/wperf/pmu_device.cpp
+++ b/wperf/pmu_device.cpp
@@ -348,6 +348,7 @@ void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
     ctl.event_filter = 0;
     UINT8 opfilter = 0;
     UINT64 config_flags = 0;
+    UINT32 interval = 0;    // 0 will force minimum indicated by PMSIDR_EL1.Interval.
     /*
     * `config_flags` stores multiple values:
     *
@@ -364,6 +365,8 @@ void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
         if (spe_device::get_filter_name(key) == L"store_filter" && val)   opfilter |= SPE_OPERATON_FILTER_ST;
         if (spe_device::get_filter_name(key) == L"branch_filter" && val)    opfilter |= SPE_OPERATON_FILTER_B;
         if (spe_device::get_filter_name(key) == L"ts_enable" && val)   config_flags |= SPE_CTL_FLAG_TS;
+        if (spe_device::get_filter_name(key) == L"jitter" && val)    config_flags |= SPE_CTL_FLAG_RND;
+        if (spe_device::get_filter_name(key) == L"period" && val)  interval = val & SPE_CTL_INTERVAL_VAL_MASK;
         if (spe_device::get_filter_name(key) == L"min_latency" && val)
         {
             UINT64 minlat = val & SPE_CTL_FLAG_VAL_MASK;   // PMSLATFR_EL1.MINLAT is 16 - bit value
@@ -372,7 +375,7 @@ void pmu_device::spe_start(const std::map<std::wstring, uint64_t>& flags)
         }
     }
     ctl.operation_filter = opfilter;
-    ctl.interval = 1024;
+    ctl.interval = interval;
     ctl.config_flags = config_flags;
 
     BOOL status = DeviceAsyncIoControl(m_device_handle, PMU_CTL_SPE_START, &ctl, sizeof(struct spe_ctl_hdr), NULL, 0, &res_len);

--- a/wperf/spe_device.cpp
+++ b/wperf/spe_device.cpp
@@ -409,7 +409,9 @@ const std::vector<std::wstring> spe_device::m_filter_names = {
     L"store_filter",
     L"branch_filter",
     L"ts_enable",
-    L"min_latency"
+    L"min_latency",
+    L"jitter",
+    L"period"
 };
 
 // Filters also have aliases, this structure helps to translate alias to filter name
@@ -418,7 +420,9 @@ const std::map<std::wstring, std::wstring> spe_device::m_filter_names_aliases = 
     { L"st",  L"store_filter" },
     { L"b" ,  L"branch_filter" },
     { L"ts",  L"ts_enable" },
-    { L"min", L"min_latency" }
+    { L"min", L"min_latency" },
+    { L"j",   L"jitter" },
+    { L"per", L"period" }
 };
 
 // Filters also have aliases, this structure helps to translate alias to filter name
@@ -427,7 +431,9 @@ const std::map<std::wstring, std::wstring> spe_device::m_filter_names_descriptio
     { L"store_filter",  L"Enables collection of store sampled operations, including all atomic operations." },
     { L"branch_filter", L"Enables collection of branch sampled operations, including direct and indirect branches and exception returns." },
     { L"ts_enable",     L"Enables timestamping with value of generic timer." },
-    { L"min_latency",   L"Collect only samples with this latency or higher." }
+    { L"min_latency",   L"Collect only samples with this latency or higher." },
+    { L"jitter",        L"Use jitter to avoid resonance when sampling." },
+    { L"pertiod",       L"Use period to set interval counter reload value. The minimum interval is used by default." },
 };
 
 spe_device::spe_device() {}

--- a/wperf/spe_device.h
+++ b/wperf/spe_device.h
@@ -77,6 +77,9 @@ public:
     {
         if (get_filter_name(fname) == L"min_latency")
             return SPE_CTL_FLAG_VAL_MASK;  // PMSLATFR_EL1, Sampling Latency Filter Register, MINLAT, bits [15:0]
+        else if (CaseInsensitiveWStringComparision(fname, L"period") ||
+            CaseInsensitiveWStringComparision(fname, L"per"))
+            return SPE_CTL_INTERVAL_VAL_MASK;   // PMSIRR_EL1, Sampling Interval Reload Register, INTERVAL, bits [31:8]
         return 1;
     }
 


### PR DESCRIPTION
## Description

** This is work in progress **

In this patch I'm introducing _jitter_ to SPE configuration. Below two new `arm_+spe_0`

- `jitter=1` - use jitter to avoid resonance when sampling (PMSIRR.RND).
- `period=<n> - The sample period is set in Linux perf from the -c option. We will pass it to SPE configuration as new filter `period=<n>` as `-c` is taken in `wperf` CLI for other setting.
  - Because the minimum interval is used by default it’s recommended to set this to a higher value. The value is written to `PMSIRR.INTERVAL`.
- added `isb()` after every sysreg write to make sure change propagates.

## Testing

This patch is causing below issue in WindowsPerf, and needs further investigation.

```posh
>wperf record -e arm_spe_0/ld=1/ -c 7 --timeout 10 -- cpython\PCbuild\arm64\python_d.exe -c...runtime delta: 0x7ff69a700000
sampling ...error: DeviceIoControl failed: GetLastError=ea
PMU_CTL_SPE_GET_BUFFER failed
```
