### PR TITLE
chore: remove outdated comments

### DIFF
--- a/wperf/parsers.cpp
+++ b/wperf/parsers.cpp
@@ -171,8 +171,6 @@ void parse_events_extra(std::wstring events_str, std::map<enum evt_class, std::v
 /*
     Example string to parse:
     $ perf record -e arm_spe_0/branch_filter=1,jitter=1/ -- workload
-    $ perf record -e arm_spe/branch_filter=1,jitter=1/ -- workload
-    $ perf record -e spe/branch_filter=1,jitter=1/ -- workload
 */
 bool parse_events_str_for_feat_spe(std::wstring events_str, std::map<std::wstring,uint64_t>& flags)
 {


### PR DESCRIPTION
## Description
This pull request includes a minor change to the `wperf/parsers.cpp` file. The change updates an example string in the comments to reflect the correct format for the `perf record` command.

Documentation Update:

* [`wperf/parsers.cpp`](diffhunk://#diff-0d642520e571f869016e285a4b77990c439bfac0c0efd517080862a961dd7146L174-L175): Updated the example string in the comments to use only `arm_spe_0` instead of `arm_spe` and `spe` cause there's no where in the source code a place where they are taken into account.

## Related Issue
No issue

## Commits
<!-- Commits will be listed automatically when the PR is created -->
${{ github.event.pull_request.commits }}

## How Has This Been Tested?
No testing needed I only removed 2 lines of comments