### PR TITLE
[wperf-test] Add more comprehensive test to check parser

### DIFF
--- a/wperf-test/wperf-test-arg_parser.cpp
+++ b/wperf-test/wperf-test-arg_parser.cpp
@@ -112,6 +112,7 @@ namespace wperftest
             parser.parse(argc, argv);
             Assert::IsTrue(parser.record_command.is_set());
             Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"notepad.exe"));
+            Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"test_arg"));
             Assert::IsTrue(COMMAND_CLASS::RECORD == parser.m_command);
         }
 
@@ -327,5 +328,83 @@ namespace wperftest
             Assert::IsTrue(check_value_in_vector(parser.output_filename_arg.get_values(), L"_output_02.json"));
             Assert::IsTrue(check_value_in_vector(parser.events_arg.get_values(), L"inst_spec,vfp_spec,ase_spec,dp_spec,ld_spec,st_spec,br_immed_spec,crypto_spec"));
         }
+
+        // Test test command with set of config
+        TEST_METHOD(test_test_json_config)
+        {
+            const wchar_t* argv[] = { L"wperf", L"test", L"--json", L"--config", L"count.period=13" };
+            const int argc = _countof(argv);
+            arg_parser parser;
+            parser.parse(argc, argv);
+
+            Assert::IsTrue(parser.test_command.is_set());
+            Assert::IsFalse(parser.record_command.is_set());
+            Assert::IsFalse(parser.list_command.is_set());
+            Assert::IsFalse(parser.help_command.is_set());
+            Assert::IsFalse(parser.version_command.is_set());
+            Assert::IsFalse(parser.detect_command.is_set());
+            Assert::IsFalse(parser.sample_command.is_set());
+            Assert::IsFalse(parser.count_command.is_set());
+            Assert::IsFalse(parser.man_command.is_set());
+
+            Assert::IsTrue(parser.json_opt.is_set());
+            Assert::IsTrue(parser.config_arg.is_set());
+            Assert::IsTrue(check_value_in_vector(parser.config_arg.get_values(), L"count.period=13"));
+            Assert::IsTrue(COMMAND_CLASS::TEST == parser.m_command);
+
+            // Double-dash aka "--"
+            Assert::IsFalse(parser.extra_args_arg.is_set());
+        }
+
+        TEST_METHOD(test_test_record_spe_with_double_dash)
+        {
+            const wchar_t* argv[] = { L"wperf", L"record", L"-e", L"arm_spe_0/load_filter=0,store_filter/", L"-c", L"4", L"--timeout", L"3", L"--json", L"--", L"python_d.exe", L"-c", L"10**10**100" };
+            const int argc = _countof(argv);
+            arg_parser parser;
+            parser.parse(argc, argv);
+
+            Assert::IsTrue(parser.record_command.is_set());
+            Assert::IsFalse(parser.list_command.is_set());
+            Assert::IsFalse(parser.test_command.is_set());
+            Assert::IsFalse(parser.help_command.is_set());
+            Assert::IsFalse(parser.version_command.is_set());
+            Assert::IsFalse(parser.detect_command.is_set());
+            Assert::IsFalse(parser.sample_command.is_set());
+            Assert::IsFalse(parser.count_command.is_set());
+            Assert::IsFalse(parser.man_command.is_set());
+
+            Assert::IsTrue(parser.json_opt.is_set());
+            Assert::IsTrue(parser.timeout_arg.is_set());
+            Assert::IsTrue(parser.cores_arg.is_set());
+            Assert::IsTrue(parser.events_arg.is_set());
+
+            // Double-dash aka "--"
+            Assert::IsTrue(parser.extra_args_arg.is_set());
+            Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"-c"));
+            Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"10**10**100"));
+
+            Assert::IsTrue(COMMAND_CLASS::RECORD == parser.m_command);
+        }
+
+        TEST_METHOD(test_record_pmu_with_double_dash)
+        {
+            const wchar_t* argv[] = { L"wperf", L"record", L"-e", L"ld_spec:100000", L"-c", L"1", L"--symbol", L"^x_mul$", L"--timeout", L"3", L"--", L"cpython\\PCbuild\\arm64\\python_d.exe", L"-c", L"10**10**100" };
+            const int argc = _countof(argv);
+            arg_parser parser;
+            parser.parse(argc, argv);
+
+            Assert::IsTrue(parser.timeout_arg.is_set());
+            Assert::IsTrue(parser.cores_arg.is_set());
+            Assert::IsTrue(parser.events_arg.is_set());
+            Assert::IsTrue(parser.symbol_arg.is_set());
+
+            // Double-dash aka "--"
+            Assert::IsTrue(parser.extra_args_arg.is_set());
+            Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"-c"));
+            Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"10**10**100"));
+
+            Assert::IsTrue(COMMAND_CLASS::RECORD == parser.m_command);
+        }
+
     };
 }

--- a/wperf-test/wperf-test-arg_parser.cpp
+++ b/wperf-test/wperf-test-arg_parser.cpp
@@ -49,9 +49,8 @@ namespace wperftest
         TEST_METHOD(test_correct_test_command)
         {
             const wchar_t* argv[] = { L"wperf", L"test", L"-v", L"--json" };
-            int argc = 4;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::AreEqual(true, parser.verbose_opt.is_set());
             Assert::AreEqual(true, parser.json_opt.is_set());
@@ -60,7 +59,7 @@ namespace wperftest
         TEST_METHOD(test_random_args_rejection)
         {
             const wchar_t* argv[] = { L"wperf", L"test", L"-v", L"--json", L"random" };
-            int argc = 5;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -71,9 +70,8 @@ namespace wperftest
         TEST_METHOD(test_help_command)
         {
             const wchar_t* argv[] = { L"wperf", L"--help" };
-            int argc = 2;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.help_command.is_set());
             Assert::IsTrue(COMMAND_CLASS::HELP == parser.m_command);
@@ -83,9 +81,8 @@ namespace wperftest
         TEST_METHOD(test_version_command)
         {
             const wchar_t* argv[] = { L"wperf", L"--version" };
-            int argc = 2;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.version_command.is_set());
             Assert::IsTrue(COMMAND_CLASS::VERSION == parser.m_command);
@@ -95,9 +92,8 @@ namespace wperftest
         TEST_METHOD(test_list_command)
         {
             const wchar_t* argv[] = { L"wperf", L"list" };
-            int argc = 2;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.list_command.is_set());
             Assert::IsTrue(COMMAND_CLASS::LIST == parser.m_command);
@@ -107,9 +103,8 @@ namespace wperftest
         TEST_METHOD(test_record_command_with_process)
         {
             const wchar_t* argv[] = { L"wperf", L"record", L"--", L"notepad.exe", L"test_arg" };
-            int argc = 5;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
             Assert::IsTrue(parser.record_command.is_set());
             Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"notepad.exe"));
             Assert::IsTrue(check_value_in_vector(parser.extra_args_arg.get_values(), L"test_arg"));
@@ -120,7 +115,7 @@ namespace wperftest
         TEST_METHOD(test_sample_command_missing_required_arg)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--timeout" };
-            int argc = 3;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -132,7 +127,7 @@ namespace wperftest
         TEST_METHOD(test_simple_invalid_argument)
         {
             const wchar_t* argv[] = { L"wperf", L"invalid_command" };
-            int argc = 2;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -144,9 +139,8 @@ namespace wperftest
         TEST_METHOD(test_timeout_with_units)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--timeout", L"2m" };
-            int argc = 4;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.timeout_arg.get_values(), L"2m"));
         }
@@ -154,7 +148,7 @@ namespace wperftest
         TEST_METHOD(test_invalid_timeout_with_wrong_format)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--timeout", L"5.4", L"ms" };
-            int argc = 5;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -166,9 +160,8 @@ namespace wperftest
         TEST_METHOD(test_detect_command)
         {
             const wchar_t* argv[] = { L"wperf", L"detect" };
-            int argc = 2;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.detect_command.is_set());
             Assert::IsTrue(COMMAND_CLASS::DETECT == parser.m_command);
@@ -178,9 +171,8 @@ namespace wperftest
         TEST_METHOD(test_multiple_flags)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--verbose", L"-q", L"--json" };
-            int argc = 5;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.verbose_opt.is_set());
             Assert::IsTrue(parser.quite_opt.is_set());
@@ -192,9 +184,8 @@ namespace wperftest
         TEST_METHOD(test_sample_command_with_symbol)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--symbol", L"main" };
-            int argc = 4;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.symbol_arg.get_values(), L"main"));
             Assert::IsTrue(COMMAND_CLASS::SAMPLE == parser.m_command);
@@ -204,9 +195,8 @@ namespace wperftest
         TEST_METHOD(test_sample_display_row)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--sample-display-row", L"100" };
-            int argc = 4;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.sample_display_row_arg.get_values(), L"100"));
             Assert::IsTrue(COMMAND_CLASS::SAMPLE == parser.m_command);
@@ -216,10 +206,9 @@ namespace wperftest
         TEST_METHOD(test_sample_command_with_pe_file)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--pe_file", L"C:\\Program\\sample.exe" };
-            int argc = 4;
             arg_parser parser;
 
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.pe_file_arg.get_values(), L"C:\\Program\\sample.exe"));
             Assert::IsTrue(COMMAND_CLASS::SAMPLE == parser.m_command);
@@ -229,11 +218,10 @@ namespace wperftest
         TEST_METHOD(test_sample_command_with_pdb_file)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--pdb_file", L"C:\\Program\\sample.pdb" };
-            int argc = 4;
             arg_parser parser;
 
             // Similarly, adjust or mock check_file_path for testing
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.pdb_file_arg.get_values(), L"C:\\Program\\sample.pdb"));
             Assert::IsTrue(COMMAND_CLASS::SAMPLE == parser.m_command);
@@ -243,9 +231,8 @@ namespace wperftest
         TEST_METHOD(test_sample_command_with_image_name)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--image_name", L"notepad.exe" };
-            int argc = 4;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(check_value_in_vector(parser.image_name_arg.get_values(), L"notepad.exe"));
             Assert::IsTrue(COMMAND_CLASS::SAMPLE == parser.m_command);
@@ -255,9 +242,8 @@ namespace wperftest
         TEST_METHOD(test_force_lock_flag)
         {
             const wchar_t* argv[] = { L"wperf", L"test", L"--force-lock" };
-            int argc = 3;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             Assert::IsTrue(parser.force_lock_opt.is_set());
             Assert::IsTrue(COMMAND_CLASS::TEST == parser.m_command);
@@ -267,9 +253,8 @@ namespace wperftest
         TEST_METHOD(test_stat_command)
         {
             const wchar_t* argv[] = { L"wperf", L"stat" };
-            int argc = 2;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
 
             // Assuming command is set correctly
             Assert::IsTrue(COMMAND_CLASS::STAT == parser.m_command);
@@ -279,7 +264,7 @@ namespace wperftest
         TEST_METHOD(test_unknown_flag)
         {
             const wchar_t* argv[] = { L"wperf", L"sample", L"--unknown" };
-            int argc = 3;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -291,7 +276,7 @@ namespace wperftest
         TEST_METHOD(test_no_command)
         {
             const wchar_t* argv[] = { L"wperf", L"--annotate", L"--json" };
-            int argc = 3;
+            const int argc = _countof(argv);
             arg_parser parser;
             Assert::ExpectException<std::invalid_argument>([&parser, argc, &argv]() {
                 parser.parse(argc, argv);
@@ -302,9 +287,8 @@ namespace wperftest
         TEST_METHOD(test_duplicate_argument)
         {
             const wchar_t* argv[] = { L"wperf", L"stat", L"-e", L"ld_spec", L"-e", L"vfp_spec" };
-            int argc = 6;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
             Assert::AreEqual(parser.events_arg.get_values().size(), size_t(2));
             Assert::IsTrue(parser.events_arg.is_set());
             Assert::IsTrue(check_value_in_vector(parser.events_arg.get_values(), L"vfp_spec"));
@@ -315,9 +299,8 @@ namespace wperftest
         TEST_METHOD(test_full_stat_command)
         {
             const wchar_t* argv[] = { L"wperf", L"stat", L"--output", L"_output_02.json", L"-e", L"inst_spec,vfp_spec,ase_spec,dp_spec,ld_spec,st_spec,br_immed_spec,crypto_spec", L"-c", L"0", L"sleep", L"5" };
-            int argc = 10;
             arg_parser parser;
-            parser.parse(argc, argv);
+            parser.parse(_countof(argv), argv);
             Assert::IsTrue(COMMAND_CLASS::STAT == parser.m_command);
             Assert::IsTrue(parser.events_arg.is_set());
             Assert::IsTrue(parser.output_filename_arg.is_set());

--- a/wperf-test/wperf-test-arg_parser.cpp
+++ b/wperf-test/wperf-test-arg_parser.cpp
@@ -301,15 +301,46 @@ namespace wperftest
             const wchar_t* argv[] = { L"wperf", L"stat", L"--output", L"_output_02.json", L"-e", L"inst_spec,vfp_spec,ase_spec,dp_spec,ld_spec,st_spec,br_immed_spec,crypto_spec", L"-c", L"0", L"sleep", L"5" };
             arg_parser parser;
             parser.parse(_countof(argv), argv);
-            Assert::IsTrue(COMMAND_CLASS::STAT == parser.m_command);
-            Assert::IsTrue(parser.events_arg.is_set());
-            Assert::IsTrue(parser.output_filename_arg.is_set());
+
+            // Check all _command flags setup
+            Assert::IsTrue(parser.count_command.is_set());
+            Assert::IsFalse(parser.record_command.is_set());
+            Assert::IsFalse(parser.list_command.is_set());
+            Assert::IsFalse(parser.help_command.is_set());
+            Assert::IsFalse(parser.version_command.is_set());
+            Assert::IsFalse(parser.detect_command.is_set());
+            Assert::IsFalse(parser.sample_command.is_set());
+            Assert::IsFalse(parser.count_command.is_set());
+            Assert::IsFalse(parser.man_command.is_set());
+
+            // Check all _arg flags setup
+            Assert::IsFalse(parser.extra_args_arg.is_set());
             Assert::IsTrue(parser.cores_arg.is_set());
             Assert::IsTrue(parser.timeout_arg.is_set());
+            Assert::IsFalse(parser.symbol_arg.is_set());
+            Assert::IsFalse(parser.record_spawn_delay_arg.is_set());
+            Assert::IsFalse(parser.sample_display_row_arg.is_set());
+            Assert::IsFalse(parser.pe_file_arg.is_set());
+            Assert::IsFalse(parser.image_name_arg.is_set());
+            Assert::IsFalse(parser.pdb_file_arg.is_set());
+            Assert::IsFalse(parser.metric_config_arg.is_set());
+            Assert::IsFalse(parser.event_config_arg.is_set());
+            Assert::IsTrue(parser.output_filename_arg.is_set());
+            Assert::IsFalse(parser.output_csv_filename_arg.is_set());
+            Assert::IsFalse(parser.output_prefix_arg.is_set());
+            Assert::IsFalse(parser.config_arg.is_set());
+            Assert::IsFalse(parser.interval_arg.is_set());
+            Assert::IsFalse(parser.iteration_arg.is_set());
+            Assert::IsFalse(parser.dmc_arg.is_set());
+            Assert::IsFalse(parser.metrics_arg.is_set());
+            Assert::IsTrue(parser.events_arg.is_set());
+
             Assert::IsTrue(check_value_in_vector(parser.timeout_arg.get_values(), L"5"));
             Assert::IsTrue(check_value_in_vector(parser.cores_arg.get_values(), L"0"));
             Assert::IsTrue(check_value_in_vector(parser.output_filename_arg.get_values(), L"_output_02.json"));
             Assert::IsTrue(check_value_in_vector(parser.events_arg.get_values(), L"inst_spec,vfp_spec,ase_spec,dp_spec,ld_spec,st_spec,br_immed_spec,crypto_spec"));
+
+            Assert::IsTrue(COMMAND_CLASS::STAT == parser.m_command);
         }
 
         // Test test command with set of config
@@ -320,6 +351,7 @@ namespace wperftest
             arg_parser parser;
             parser.parse(argc, argv);
 
+            // Check all _command flags setup
             Assert::IsTrue(parser.test_command.is_set());
             Assert::IsFalse(parser.record_command.is_set());
             Assert::IsFalse(parser.list_command.is_set());
@@ -330,8 +362,40 @@ namespace wperftest
             Assert::IsFalse(parser.count_command.is_set());
             Assert::IsFalse(parser.man_command.is_set());
 
-            Assert::IsTrue(parser.json_opt.is_set());
+            // Check all _arg flags setup
+            Assert::IsFalse(parser.extra_args_arg.is_set());
+            Assert::IsFalse(parser.cores_arg.is_set());
+            Assert::IsFalse(parser.timeout_arg.is_set());
+            Assert::IsFalse(parser.symbol_arg.is_set());
+            Assert::IsFalse(parser.record_spawn_delay_arg.is_set());
+            Assert::IsFalse(parser.sample_display_row_arg.is_set());
+            Assert::IsFalse(parser.pe_file_arg.is_set());
+            Assert::IsFalse(parser.image_name_arg.is_set());
+            Assert::IsFalse(parser.pdb_file_arg.is_set());
+            Assert::IsFalse(parser.metric_config_arg.is_set());
+            Assert::IsFalse(parser.event_config_arg.is_set());
+            Assert::IsFalse(parser.output_filename_arg.is_set());
+            Assert::IsFalse(parser.output_csv_filename_arg.is_set());
+            Assert::IsFalse(parser.output_prefix_arg.is_set());
             Assert::IsTrue(parser.config_arg.is_set());
+            Assert::IsFalse(parser.interval_arg.is_set());
+            Assert::IsFalse(parser.iteration_arg.is_set());
+            Assert::IsFalse(parser.dmc_arg.is_set());
+            Assert::IsFalse(parser.metrics_arg.is_set());
+            Assert::IsFalse(parser.events_arg.is_set());
+
+            // Check all _opt flags setup
+            Assert::IsTrue(parser.json_opt.is_set());
+            Assert::IsFalse(parser.kernel_opt.is_set());
+            Assert::IsFalse(parser.force_lock_opt.is_set());
+            Assert::IsFalse(parser.sample_display_long_opt.is_set());
+            Assert::IsFalse(parser.verbose_opt.is_set());
+            Assert::IsFalse(parser.quite_opt.is_set());
+            Assert::IsFalse(parser.annotate_opt.is_set());
+            Assert::IsFalse(parser.disassembly_opt.is_set());
+            Assert::IsFalse(parser.timeline_opt.is_set());
+
+
             Assert::IsTrue(check_value_in_vector(parser.config_arg.get_values(), L"count.period=13"));
             Assert::IsTrue(COMMAND_CLASS::TEST == parser.m_command);
 
@@ -356,9 +420,37 @@ namespace wperftest
             Assert::IsFalse(parser.count_command.is_set());
             Assert::IsFalse(parser.man_command.is_set());
 
+            // Check all _opt flags setup
             Assert::IsTrue(parser.json_opt.is_set());
-            Assert::IsTrue(parser.timeout_arg.is_set());
+            Assert::IsFalse(parser.kernel_opt.is_set());
+            Assert::IsFalse(parser.force_lock_opt.is_set());
+            Assert::IsFalse(parser.sample_display_long_opt.is_set());
+            Assert::IsFalse(parser.verbose_opt.is_set());
+            Assert::IsFalse(parser.quite_opt.is_set());
+            Assert::IsFalse(parser.annotate_opt.is_set());
+            Assert::IsFalse(parser.disassembly_opt.is_set());
+            Assert::IsFalse(parser.timeline_opt.is_set());
+
+            // Check all _arg flags setup
+            Assert::IsFalse(parser.extra_args_arg.is_set());
             Assert::IsTrue(parser.cores_arg.is_set());
+            Assert::IsTrue(parser.timeout_arg.is_set());
+            Assert::IsFalse(parser.symbol_arg.is_set());
+            Assert::IsFalse(parser.record_spawn_delay_arg.is_set());
+            Assert::IsFalse(parser.sample_display_row_arg.is_set());
+            Assert::IsFalse(parser.pe_file_arg.is_set());
+            Assert::IsFalse(parser.image_name_arg.is_set());
+            Assert::IsFalse(parser.pdb_file_arg.is_set());
+            Assert::IsFalse(parser.metric_config_arg.is_set());
+            Assert::IsFalse(parser.event_config_arg.is_set());
+            Assert::IsFalse(parser.output_filename_arg.is_set());
+            Assert::IsFalse(parser.output_csv_filename_arg.is_set());
+            Assert::IsFalse(parser.output_prefix_arg.is_set());
+            Assert::IsFalse(parser.config_arg.is_set());
+            Assert::IsFalse(parser.interval_arg.is_set());
+            Assert::IsFalse(parser.iteration_arg.is_set());
+            Assert::IsFalse(parser.dmc_arg.is_set());
+            Assert::IsFalse(parser.metrics_arg.is_set());
             Assert::IsTrue(parser.events_arg.is_set());
 
             // Double-dash aka "--"

--- a/wperf-test/wperf-test-arg_parser.cpp
+++ b/wperf-test/wperf-test-arg_parser.cpp
@@ -303,14 +303,13 @@ namespace wperftest
             parser.parse(_countof(argv), argv);
 
             // Check all _command flags setup
-            Assert::IsTrue(parser.count_command.is_set());
             Assert::IsFalse(parser.record_command.is_set());
             Assert::IsFalse(parser.list_command.is_set());
             Assert::IsFalse(parser.help_command.is_set());
             Assert::IsFalse(parser.version_command.is_set());
             Assert::IsFalse(parser.detect_command.is_set());
             Assert::IsFalse(parser.sample_command.is_set());
-            Assert::IsFalse(parser.count_command.is_set());
+            Assert::IsTrue(parser.count_command.is_set());
             Assert::IsFalse(parser.man_command.is_set());
 
             // Check all _arg flags setup
@@ -432,7 +431,7 @@ namespace wperftest
             Assert::IsFalse(parser.timeline_opt.is_set());
 
             // Check all _arg flags setup
-            Assert::IsFalse(parser.extra_args_arg.is_set());
+            Assert::IsTrue(parser.extra_args_arg.is_set());
             Assert::IsTrue(parser.cores_arg.is_set());
             Assert::IsTrue(parser.timeout_arg.is_set());
             Assert::IsFalse(parser.symbol_arg.is_set());


### PR DESCRIPTION
## Description

This tests are checking all opts, args and commands when we parse the command. 
There are some regressions, see screenshot below:
```
 test_full_stat_command
   Source: wperf-test-arg_parser.cpp line 299
   Duration: 128 ms

  Message: 
Assert failed

  Stack Trace: 
ArgParser::test_full_stat_command() line 314
```

```
 test_test_record_spe_with_double_dash
   Source: wperf-test-arg_parser.cpp line 406
   Duration: 1 ms

  Message: 
Assert failed

  Stack Trace: 
ArgParser::test_test_record_spe_with_double_dash() line 436
```

## How Has This Been Tested?

![image](https://github.com/user-attachments/assets/a4119190-333f-4dc7-be3f-4cfdfd31087c)
