### PR TITLE
[docs]: Typo in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,7 +4,7 @@
 
 | `wperf` Command     | Description |
 | ---                 | ---         |
-| `wperf -–help`      | Run wperf help command, see detailed command line syntax. |
+| `wperf --help`      | Run wperf help command, see detailed command line syntax. |
 | `wperf --version`   | Display version of the driver and CLI application. |
 | `wperf list`        | List supported events and metrics. Enable verbose mode for more details. |
 | `wperf test`        | Configuration information about driver and application. |


### PR DESCRIPTION
## Description

There was a Unicode character in USAGE.md which is removed with this patch.
