### PR TITLE
[wperf-test]: add arg_parser.obj and arg_parser_arg.obj to all linkages

### DIFF
--- a/wperf-test/wperf-test.vcxproj
+++ b/wperf-test/wperf-test.vcxproj
@@ -170,7 +170,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories);;$(SolutionDir)\wperf\$(Platform)\$(Configuration)\;$(SolutionDir)\wperf-lib\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj</AdditionalDependencies>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj;arg_parser.obj;arg_parser_arg.obj</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -240,7 +240,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories);;$(SolutionDir)\wperf\$(Platform)\$(Configuration)\;$(SolutionDir)\wperf-lib\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj</AdditionalDependencies>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj;arg_parser.obj;arg_parser_arg.obj</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -259,7 +259,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories);;$(SolutionDir)\wperf\$(Platform)\$(Configuration)\;$(SolutionDir)\wperf-lib\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj</AdditionalDependencies>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);utils.obj;pe_file.obj;output.obj;parsers.obj;events.obj;padding.obj;metric.obj;wperf.obj;pmu_device.obj;spe_device.obj;wperf-lib.obj;process_api.obj;config.obj;timeline.obj;perfdata.obj;user_request.obj;arg_parser.obj;arg_parser_arg.obj</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
We can't how build e.g. `Debug+SPE` configuration.

This patch is simply adding missing `.obj` files to all remaining `wperf-test` configurations.

## Testing
```
...
14:51:57:881	9>Done building project "wperf-test.vcxproj".
14:51:57:886	========== Rebuild All: 8 succeeded, 0 failed, 1 skipped ==========
14:51:57:886	========== Rebuild completed at 14:51 and took 02:04.483 minutes ==========
```